### PR TITLE
useThrottledFunction: Throw if `delay` parameter changes

### DIFF
--- a/react-frontend/src/hooks/useThrottledFunction.js
+++ b/react-frontend/src/hooks/useThrottledFunction.js
@@ -116,6 +116,11 @@ function throttledFunction(delay, fn) {
 //
 // Thanks to Adam Comella.
 export default function useThrottledFunction(delay, fn) {
+  const [prevDelay, _] = useState(delay);
+  if (delay !== prevDelay) {
+    throw new Error('useThrottledFunction: Changing the `delay` parameter between invocations is currently not supported.');
+  }
+
   const [[throttledFn, setFn, disposeThrottledFn], _] = useState(() => {
     return throttledFunction(delay, fn);
   });


### PR DESCRIPTION
## Problem

`useThrottledFunction's` current implementation doesn't properly handle the case that the `delay` parameter changes between invocations

`useThrottledFunction` uses the first value of `delay` it receives. If later invocations of `useThrottledFunction` have different values for `delay`, those values will silently be ignored. It's unlikely that this is the behavior the caller is expecting.

## Mitigation

This PR updates `useThrottledFunction` to throw if `delay` changes between invocations. This will make it easy for engineers to realize that `useThrottledFunction` is ignoring their new `delay` value.

## Future

If the use case arises where the `delay` argument needs to change between invocations, we can invest the time to implement proper support for it. In that case, we'd likely want to call `throttledFunction` to create a new throttled function with the new `delay` value.

## Testing

I do not have the dev environment set up so I wasn't able to test this change.