### PR TITLE
Configurable webRTC backend support (adds MediaMTX)

### DIFF
--- a/react-frontend/public/configEnv.js
+++ b/react-frontend/public/configEnv.js
@@ -14,6 +14,8 @@ window.SEALOG_URL = "https://sealog.whoi.edu/sealog-alvin/";
 
 // Video stream server configs
 window.VIDEO_STREAM_SERVER = "https://128.128.184.62/video";
+window.VIDEO_STREAM_PROTOCOL = "whep";
+window.VIDEO_STREAM_URL_TEMPLATE = "/stream/{stream}/channel/{channel}/webrtc/whep";
 window.PORT_OBSERVER_VIDEO = "port_obs";
 window.PORT_OBSERVER_SMALL_VIDEO = "port_obs_small";
 window.PORT_RECORDER_VIDEO = "port_rec";

--- a/react-frontend/src/config.js
+++ b/react-frontend/src/config.js
@@ -69,6 +69,8 @@ export const COMMAND_STRINGS = {
 
 export const VIDEO_STREAM_CONFIG = {
   server: envSettings.VIDEO_STREAM_SERVER,
+  protocol: envSettings.VIDEO_STREAM_PROTOCOL,
+  urlTemplate: envSettings.VIDEO_STREAM_URL_TEMPLATE,
   portObserverVideo: envSettings.PORT_OBSERVER_VIDEO,
   portObserverSmallVideo: envSettings.PORT_OBSERVER_SMALL_VIDEO,
   stbdObserverVideo: envSettings.STBD_OBSERVER_VIDEO,

--- a/react-frontend/src/features/camera-controls/LargeVideo.jsx
+++ b/react-frontend/src/features/camera-controls/LargeVideo.jsx
@@ -8,6 +8,8 @@ import { VIDEO_STREAM_CONFIG } from "../../config.js";
 import { selectLastCommand } from "./cameraControlsSlice";
 
 WebRtcPlayer.setServer(VIDEO_STREAM_CONFIG.server);
+WebRtcPlayer.setProtocol(VIDEO_STREAM_CONFIG.protocol);
+WebRtcPlayer.setUrlTemplate(VIDEO_STREAM_CONFIG.urlTemplate);
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/react-frontend/src/features/observer-ui/MiniVideo.jsx
+++ b/react-frontend/src/features/observer-ui/MiniVideo.jsx
@@ -9,6 +9,8 @@ import { VIDEO_STREAM_CONFIG } from "../../config.js";
 import { selectLastCommand } from "../camera-controls/cameraControlsSlice";
 
 WebRtcPlayer.setServer(VIDEO_STREAM_CONFIG.server);
+WebRtcPlayer.setProtocol(VIDEO_STREAM_CONFIG.protocol);
+WebRtcPlayer.setUrlTemplate(VIDEO_STREAM_CONFIG.urlTemplate);
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/react-frontend/src/features/pilot-ui/MiniVideo.jsx
+++ b/react-frontend/src/features/pilot-ui/MiniVideo.jsx
@@ -7,6 +7,8 @@ import MiniVideoHeader from "./MiniVideoHeader";
 import { VIDEO_STREAM_CONFIG } from "../../config.js";
 
 WebRtcPlayer.setServer(VIDEO_STREAM_CONFIG.server);
+WebRtcPlayer.setProtocol(VIDEO_STREAM_CONFIG.protocol);
+WebRtcPlayer.setUrlTemplate(VIDEO_STREAM_CONFIG.urlTemplate);
 
 const useStyles = makeStyles((theme) => ({
   root: {

--- a/react-frontend/src/utils/webrtcplayer.js
+++ b/react-frontend/src/utils/webrtcplayer.js
@@ -1,7 +1,11 @@
 export default class WebRtcPlayer {
   static server = "http://127.0.0.1:8083";
+  static protocol = "whep";
+  static urlTemplate = "/stream/{stream}/channel/{channel}/webrtc/whep";
 
   server = null;
+  protocol = null;
+  urlTemplate = null;
   stream = null;
   channel = null;
 
@@ -11,6 +15,8 @@ export default class WebRtcPlayer {
 
   constructor(id, stream, channel) {
     this.server = WebRtcPlayer.server;
+    this.protocol = WebRtcPlayer.protocol;
+    this.urlTemplate = WebRtcPlayer.urlTemplate;
     this.video = document.getElementById(id);
     this.stream = stream;
     this.channel = channel;
@@ -34,10 +40,10 @@ export default class WebRtcPlayer {
   }
 
   getStreamUrl() {
-    
-    // RTSPtoWeb only, not RTSPtoWebRTC
-    return `${this.server}/stream/${this.stream}/channel/${this.channel}/webrtc`;
-          
+    const template = this.urlTemplate
+      .replaceAll("{stream}", this.stream ?? "")
+      .replaceAll("{channel}", this.channel ?? "");
+    return `${this.server}${template}`;
   }
 
   async play() {
@@ -45,7 +51,7 @@ export default class WebRtcPlayer {
     this.mediastream = new MediaStream();
     this.video.srcObject = this.mediastream;
     console.log("webRTC play:", this.stream, this.mediastream);
-    
+
     // close any existing connections  //I don't think this is appropriate here - need to clean up tracks via close() first - mjs
     //if (this.webrtc) {
     //  console.log("webrtc.play() -  Close any existing connections"); //logging-mjs
@@ -53,22 +59,38 @@ export default class WebRtcPlayer {
     //}
 
     this.webrtc = new RTCPeerConnection({
-      iceServers: [
-        {
-          urls: ["stun:stun.l.google.com:19302"],
-        },
-      ],
+      iceServers: [],
       sdpSemantics: "unified-plan",
     });
 
+
     //this.webrtc.ontrack = this.handleTrack.bind(this); //move before negotiation - mjs test
     this.webrtc.onnegotiationneeded = this.handleNegotiationNeeded.bind(this);
-    this.webrtc.onsignalingstatechange = this.handleSignalingStateChange.bind(this);
     this.webrtc.ontrack = this.handleTrack.bind(this);
     this.webrtc.onremovetrack = this.removeTrack.bind(this); //mjs - 11sept2024
 
     this.webrtc.addTransceiver("video", {
-      direction: "sendrecv",
+      direction: "recvonly",
+    });
+  }
+
+  async waitForIceGatheringComplete() {
+    if (this.webrtc.iceGatheringState === "complete") {
+      return;
+    }
+
+    await new Promise((resolve) => {
+      const checkState = () => {
+        if (this.webrtc.iceGatheringState === "complete") {
+          this.webrtc.removeEventListener(
+            "icegatheringstatechange",
+            checkState
+          );
+          resolve();
+        }
+      };
+
+      this.webrtc.addEventListener("icegatheringstatechange", checkState);
     });
   }
 
@@ -80,125 +102,137 @@ export default class WebRtcPlayer {
     });
     console.log("webRTC - handleNegotiationNeeded - offer:", this.stream, offer, this.mediastream);
     await this.webrtc.setLocalDescription(offer);
+    await this.waitForIceGatheringComplete();
+
+    try {
+      const response = await this.sendOffer();
+      await this.webrtc.setRemoteDescription(
+        new RTCSessionDescription({
+          type: "answer",
+          sdp: response,
+        })
+      );
+    } catch (error) {
+      console.log(`webRTC - ERROR: handleNegotiationNeeded ${this.stream} : ${error}`);
+    }
   }
 
-  async handleSignalingStateChange() {
-    //console.log(`handleSignalingStateChange ${this.webrtc.signalingState}`);
-    console.log("webRTC - handleSignalingStateChange:", this.stream, this.webrtc.signalingState);
-    try {  //added to catch error when no video source available - 30may2024 - mjs
-      switch (this.webrtc.signalingState) {
-        case "have-local-offer":
-          let formData = new FormData();
-          formData.append("data", btoa(this.webrtc.localDescription.sdp));
-        
-        
-          const response = await fetch(this.getStreamUrl(), {
-            method: "POST",
-            body: formData,
-          });
-        
-          this.webrtc.setRemoteDescription(
-            new RTCSessionDescription({
-              type: "answer",
-              sdp: atob(await response.text()),
-            })
-          );
-        
-          break;
+  async sendOffer() {
+    switch (this.protocol) {
+      case "whep":
+        return this.sendWhepOffer();
+      case "rtsptoweb":
+        return this.sendRtspToWebOffer();
+      default:
+        throw new Error(`Unsupported video stream protocol: ${this.protocol}`);
+    }
+  }
 
-        case "stable":
-          /*
-           * There is no ongoing exchange of offer and answer underway.
-           * This may mean that the RTCPeerConnection object is new, in which case both the localDescription and remoteDescription are null;
-           * it may also mean that negotiation is complete and a connection has been established.
-           */
-          break;
+  async sendWhepOffer() {
+    const response = await fetch(this.getStreamUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/sdp",
+      },
+      body: this.webrtc.localDescription.sdp,
+    });
+    const body = await response.text();
 
-        case "closed":
-          /*
-           * The RTCPeerConnection has been closed.
-           */
-          //console.log('The RTCPeerConnection has been closed: ${this.webrtc.signalingState}`);
-          console.log("webRTC - RTCPeerConnection has been closed:", this.stream, this.webrtc.signalingState);
-          break;
+    if (!response.ok) {
+      throw new Error(`WHEP request failed: ${response.status} ${body}`);
+    }
 
-        default:
-          //console.log(`unhandled signalingState is ${this.webrtc.signalingState}`);
-          console.log("webRTC - unhandled signalingState:", this.stream, this.webrtc.signalingState);
-          break;
-      }
-    
-    } 
-    catch (error) {
-      console.log(`webRTC - ERROR: handleSignalingStateChange ${this.stream} : ${this.webrtc.signalingState} : ${error}`);
-    }   
-    
+    return body;
+  }
+
+  async sendRtspToWebOffer() {
+    const formData = new FormData();
+    formData.append("data", btoa(this.webrtc.localDescription.sdp));
+
+    const response = await fetch(this.getStreamUrl(), {
+      method: "POST",
+      body: formData,
+    });
+    const body = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`RTSPtoWeb request failed: ${response.status} ${body}`);
+    }
+
+    return atob(body);
   }
 
   handleTrack(event) {
     console.log("webRTC - handle track", this.stream, event);
     this.mediastream.addTrack(event.track);
   }
-  
-  
+
+
   removeTrack(event) {
     console.log("webRTC - remove track", this.stream, event);
     this.mediastream.removeTrack(event.track);
   }
 
   async close() {
-    
+
     console.log("webRTC - Closing connection", this.stream);
-    
+
     if (this.webrtc) {
       this.mediastream.getTracks().forEach(track => {
         console.log("webRTC - Closing stream tracks", this.stream);
         track.enabled = false;
         track.stop()
         //this.mediastream.removeTrack(track);
-      }); 
-    
-           
-           
-      
-    
-    
+      });
+
+
+
+
+
+
       this.webrtc.ontrack = null;
       //this.webrtc.onremovetrack = null;
       //this.webrtc.onicecandidate = null;
       //this.webrtc.oniceconnectionstatechange = null;
       this.webrtc.onnegotiationneeded = null;
-      this.webrtc.onsignalingstatechange = null;
-    
-         
+
+
       this.webrtc.close();
       //this.close();
-      
+
       //this.server = null;
       //this.stream = null;
       //this.channel = null;
 
       //this.webrtc = null;
       this.mediastream = null;
-      
+
       this.video.srcObject = null;
-     
+
       //this.video.src = '';
-     
+
       //this.video = null; 
       //this.video.remove();
       //this.video.pause();
-      
+
       console.log("webRTC - Connection closed!", this.stream);
-   
+
     } else {
-    
+
       console.log("webRTC not found!", this.stream);
     }
-  }    
-       
-  
+  }
+
+
   static setServer(serv) {
     this.server = serv;
+  }
+
+  static setProtocol(protocol) {
+    this.protocol = (protocol || "whep").toLowerCase();
+  }
+
+  static setUrlTemplate(urlTemplate) {
+    this.urlTemplate = urlTemplate || "/stream/{stream}/channel/{channel}/webrtc/whep";
   }
 }


### PR DESCRIPTION
ObserverUI currently hardcodes some routes and signaling that the RTSPtoWeb backend uses. This adds support for WHEP signaling standard, as used by MediaMTX.