### PR TITLE
Add SystemMessageListener for API v1.5 endpoint

### DIFF
--- a/react-frontend/public/configEnv.js
+++ b/react-frontend/public/configEnv.js
@@ -3,11 +3,11 @@
 
 window.PILOT_MODE = false;
 
-// Web socket server root URL
-window.WS_SERVER = "https://128.128.184.62";
-//window.WS_SERVER = "https://128.128.184.62";
-// Web socket server path, ex: "/websocket-server-path/"
-window.WS_PATH = "/imaging-control/";
+// Web socket endpoints by backend API version.
+window.WS_ENDPOINTS = {
+  "1":   { server: "https://128.128.184.62", path: "/imaging-control/" },
+  "1.5": { server: "https://128.128.184.62", path: "/api/v1.5/" },
+};
 
 // sealog url for iframe
 window.SEALOG_URL = "https://sealog.whoi.edu/sealog-alvin/";

--- a/react-frontend/src/App.jsx
+++ b/react-frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import AppPilot from "./AppPilot.jsx";
 import AppObserver from "./AppObserver.jsx";
+import SystemMessageListener from "./features/listeners/SystemMessageListener.jsx";
 
 export default function App() {
-  if (window.PILOT_MODE === true) {
-    return <AppPilot />;
-  } else {
-    return <AppObserver />;
-  }
+  return (
+    <>
+      <SystemMessageListener />
+      {window.PILOT_MODE === true ? <AppPilot /> : <AppObserver />}
+    </>
+  );
 }

--- a/react-frontend/src/config.js
+++ b/react-frontend/src/config.js
@@ -1,9 +1,8 @@
 // Get the environmental variables from the window object
 // Local file: /public/configEnv.js
 const envSettings = window;
-// Web socket server
-export const WS_SERVER = envSettings.WS_SERVER;
-export const WS_PATH = envSettings.WS_PATH;
+// One entry per backend API version. Each entry is { server, path }.
+export const WS_ENDPOINTS = envSettings.WS_ENDPOINTS;
 export const WS_SERVER_NAMESPACE_PORT = "port";
 export const WS_SERVER_NAMESPACE_STARBOARD = "stbd";
 export const WS_SERVER_NAMESPACE_PILOT = "pilot";

--- a/react-frontend/src/features/listeners/SystemMessageListener.jsx
+++ b/react-frontend/src/features/listeners/SystemMessageListener.jsx
@@ -1,0 +1,19 @@
+import React, { useCallback } from "react";
+import { useSocketListener } from "../../hooks/useSocket";
+
+const SYSTEM_MESSAGE_EVENT = "SystemMessage";
+
+// Holds open a socket to the v1.5 /system namespace and logs every
+// incoming SystemMessage. Renders nothing.
+export default function SystemMessageListener() {
+  const handleMessage = useCallback((message) => {
+    // eslint-disable-next-line no-console
+    console.log("[SystemMessage]", message);
+  }, []);
+
+  useSocketListener("/system", SYSTEM_MESSAGE_EVENT, handleMessage, {
+    apiVersion: "1.5",
+  });
+
+  return null;
+}

--- a/react-frontend/src/hooks/useSocket.js
+++ b/react-frontend/src/hooks/useSocket.js
@@ -1,28 +1,34 @@
 import { useEffect, useRef, useState } from "react";
 import socketIOClient from "socket.io-client";
-import { WS_SERVER, WS_PATH } from "../config";
+import { WS_ENDPOINTS } from "../config";
 
-// Simple shared socket pool by namespace (e.g., "/", "/pilot", "/port").
+// Shared socket pool keyed by `${apiVersion}:${namespace}` so the same
+// namespace name can coexist on different backend API versions.
 const pool = new Map();
 
-function getOrCreate(namespace) {
-  let entry = pool.get(namespace);
+function getOrCreate(namespace, apiVersion) {
+  const key = `${apiVersion}:${namespace}`;
+  let entry = pool.get(key);
   if (!entry) {
-    const socket = socketIOClient(WS_SERVER + namespace, {
-      path: WS_PATH + "socket.io",
+    const endpoint = WS_ENDPOINTS[apiVersion];
+    if (!endpoint) {
+      throw new Error(`No WS_ENDPOINTS entry for API version ${apiVersion}`);
+    }
+    const socket = socketIOClient(endpoint.server + namespace, {
+      path: endpoint.path + "socket.io",
       transports: ["websocket"],
     });
-    entry = { socket, refCount: 0 };
-    pool.set(namespace, entry);
+    entry = { socket, refCount: 0, key };
+    pool.set(key, entry);
   }
   return entry;
 }
 
-export function useSocket(namespace = "/") {
+export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
   const entryRef = useRef(null);
 
   useEffect(() => {
-    const entry = getOrCreate(namespace);
+    const entry = getOrCreate(namespace, apiVersion);
     entry.refCount += 1;
     entryRef.current = entry;
 
@@ -31,7 +37,7 @@ export function useSocket(namespace = "/") {
       if (!e) return;
       e.refCount -= 1;
       if (e.refCount <= 0) {
-        pool.delete(namespace);
+        pool.delete(e.key);
 
         // Good bye message to server is a historical part of the ICS protocol
         try {
@@ -44,15 +50,20 @@ export function useSocket(namespace = "/") {
         e.socket.disconnect();
       }
     };
-  }, [namespace]);
+  }, [namespace, apiVersion]);
 
   return entryRef.current
     ? entryRef.current.socket
-    : getOrCreate(namespace).socket;
+    : getOrCreate(namespace, apiVersion).socket;
 }
 
-export function useSocketListener(namespace = "/", event, callback) {
-  const socket = useSocket(namespace);
+export function useSocketListener(
+  namespace = "/",
+  event,
+  callback,
+  { apiVersion = "1" } = {}
+) {
+  const socket = useSocket(namespace, { apiVersion });
   const callbackRef = useRef(callback);
 
   useEffect(() => {

--- a/react-frontend/tests/setup.ts
+++ b/react-frontend/tests/setup.ts
@@ -7,5 +7,7 @@ import { initInterceptor } from "./ws-interceptor";
 initInterceptor();
 
 // Populate settings used for Socket.IO connections
-window.WS_SERVER = "http://example.invalid";
-window.WS_PATH = "/imaging-server/";
+window.WS_ENDPOINTS = {
+  "1":   { server: "http://example.invalid", path: "/imaging-server/" },
+  "1.5": { server: "http://example.invalid", path: "/api/v1.5/" },
+};


### PR DESCRIPTION
See https://github.com/WHOIGit/suboptica/pull/84

This adds a simple `SystemMessageListener` which receives `/system` messages carrying alerts by the server.

This changes the socket coalescing behavior to support an API version tag so that this Socket.IO connection has handled by the `/api/v1.5/` backend.

Claude Code, Opus 4.7, max effort