### PR TITLE
Fix RecorderHeartbeatListener namespace

### DIFF
--- a/react-frontend/src/features/listeners/RecorderHeartbeatListener.jsx
+++ b/react-frontend/src/features/listeners/RecorderHeartbeatListener.jsx
@@ -1,11 +1,20 @@
-import React, { useCallback } from "react";
-import { useDispatch } from "react-redux";
+import React, { useCallback, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useSocketListener } from "../../hooks/useSocket";
 import { RECORDER_HEARTBEAT } from "../../config";
-import { changeRecorderHeartbeat } from "../camera-controls/cameraControlsSlice";
+import {
+  changeRecorderHeartbeat,
+  selectObserverSide,
+} from "../camera-controls/cameraControlsSlice";
+import { getObserverInfo } from "../../utils/observerSide";
 
 export default function RecorderHeartbeatListener({ isEnabled = true }) {
   const dispatch = useDispatch();
+  const observerSide = useSelector(selectObserverSide);
+  const namespaceInfo = useMemo(
+    () => getObserverInfo(observerSide),
+    [observerSide]
+  );
 
   const handleMessage = useCallback(
     (message) => {
@@ -14,7 +23,11 @@ export default function RecorderHeartbeatListener({ isEnabled = true }) {
     [dispatch]
   );
 
-  useSocketListener("/", RECORDER_HEARTBEAT, handleMessage);
+  useSocketListener(
+    namespaceInfo.namespacePath,
+    RECORDER_HEARTBEAT,
+    handleMessage
+  );
 
   return null;
 }


### PR DESCRIPTION
`RecorderHeartbeatListener` now subscribes on the observer-side namespace (`/port`, `/stbd`, `/pilot`) derived from the redux `observerSide`, instead of the root `/` namespace.

We didn't have a test case (and still don't) because it's tricky to test Socket.IO and I don't think we have a means right now to test for this.

Fixes #26.