### PR TITLE
System message alerts: source-driven highlighting + heartbeat staleness

### DIFF
--- a/react-frontend/src/App.jsx
+++ b/react-frontend/src/App.jsx
@@ -1,11 +1,13 @@
 import AppPilot from "./AppPilot.jsx";
 import AppObserver from "./AppObserver.jsx";
 import SystemMessageListener from "./features/listeners/SystemMessageListener.jsx";
+import HeartbeatWatchdog from "./features/heartbeats/HeartbeatWatchdog.jsx";
 
 export default function App() {
   return (
     <>
       <SystemMessageListener />
+      <HeartbeatWatchdog />
       {window.PILOT_MODE === true ? <AppPilot /> : <AppObserver />}
     </>
   );

--- a/react-frontend/src/features/heartbeats/HeartbeatWatchdog.jsx
+++ b/react-frontend/src/features/heartbeats/HeartbeatWatchdog.jsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useSocketListener } from "../../hooks/useSocket";
+import { getObserverInfo } from "../../utils/observerSide";
+import {
+  selectObserverSide,
+  setSocketError,
+} from "../camera-controls/cameraControlsSlice";
+import {
+  addSystemMessage,
+  dismissSystemMessage,
+} from "../system-messages/systemMessagesSlice";
+import { HEARTBEAT_STREAMS, evaluateStaleStreams } from "./streams";
+
+const CHECK_INTERVAL_MS = 5000;
+const STALE_ID_PREFIX = "heartbeat-stale-";
+
+const staleMessageId = (key) => `${STALE_ID_PREFIX}${key}`;
+
+// Subscribes to one heartbeat event and stamps the time each message arrives.
+// Renders nothing; one is mounted per watched stream.
+function StreamSubscriber({ stream, namespace, onSeen }) {
+  const handleMessage = useCallback(() => onSeen(stream.key), [onSeen, stream.key]);
+  useSocketListener(namespace, stream.event, handleMessage);
+  return null;
+}
+
+// Watches every heartbeat stream for liveness. When a stream stops updating it
+// raises a single WARN/ERROR system message (which both lands in the
+// notification bar and lights up the matching control via AlertHighlight) and
+// clears it on recovery. Losing the imaging-server heartbeats (camera/recorder)
+// additionally drives the connection-error chip. Renders only its subscribers.
+export default function HeartbeatWatchdog() {
+  const dispatch = useDispatch();
+  const observerSide = useSelector(selectObserverSide);
+  const sideNamespacePath = getObserverInfo(observerSide).namespacePath;
+
+  const lastSeenRef = useRef({});
+  const flaggedRef = useRef(new Set());
+
+  const handleSeen = useCallback((key) => {
+    lastSeenRef.current[key] = Date.now();
+  }, []);
+
+  useEffect(() => {
+    const tick = () => {
+      const stale = evaluateStaleStreams(lastSeenRef.current, Date.now());
+      const flagged = flaggedRef.current;
+
+      HEARTBEAT_STREAMS.forEach((stream) => {
+        const isStale = Boolean(stale[stream.key]);
+        const wasFlagged = flagged.has(stream.key);
+
+        if (isStale && !wasFlagged) {
+          dispatch(
+            addSystemMessage({
+              correlation_id: staleMessageId(stream.key),
+              timestamp: new Date().toISOString(),
+              message: `${stream.label} heartbeat lost (no update in ${Math.round(
+                stream.staleMs / 1000
+              )}s)`,
+              level: stream.level,
+              source: stream.source,
+            })
+          );
+          flagged.add(stream.key);
+        } else if (!isStale && wasFlagged) {
+          dispatch(dismissSystemMessage(staleMessageId(stream.key)));
+          flagged.delete(stream.key);
+        }
+      });
+
+      // Revive the otherwise-dead imaging connection chip when the imaging
+      // server's heartbeats have gone quiet.
+      dispatch(setSocketError(Boolean(stale.camera || stale.recorder)));
+    };
+
+    const intervalId = window.setInterval(tick, CHECK_INTERVAL_MS);
+    tick();
+    return () => window.clearInterval(intervalId);
+  }, [dispatch]);
+
+  return (
+    <>
+      {HEARTBEAT_STREAMS.map((stream) => (
+        <StreamSubscriber
+          key={stream.key}
+          stream={stream}
+          namespace={
+            stream.namespace === "side" ? sideNamespacePath : stream.namespace
+          }
+          onSeen={handleSeen}
+        />
+      ))}
+    </>
+  );
+}

--- a/react-frontend/src/features/heartbeats/streams.js
+++ b/react-frontend/src/features/heartbeats/streams.js
@@ -1,0 +1,66 @@
+import {
+  CAM_HEARTBEAT,
+  NAV_HEARTBEAT,
+  RECORDER_HEARTBEAT,
+  SENSOR_HEARTBEAT,
+} from "../../config";
+
+// Heartbeat streams the client watches for liveness. Each entry ties a stream
+// to the control highlight that should light up when it goes quiet (`source`,
+// matched against AlertHighlight / SOURCE_META) and how long without an update
+// counts as stale. `namespace: "side"` means the stream rides the active
+// observer-side namespace; "/" is the shared default namespace.
+export const HEARTBEAT_STREAMS = [
+  {
+    key: "nav",
+    event: NAV_HEARTBEAT,
+    namespace: "/",
+    source: "telemetry",
+    label: "Navigation",
+    level: "WARN",
+    staleMs: 15000,
+  },
+  {
+    key: "sensor",
+    event: SENSOR_HEARTBEAT,
+    namespace: "/",
+    source: "sensor",
+    label: "Sensor",
+    level: "WARN",
+    staleMs: 30000,
+  },
+  {
+    key: "camera",
+    event: CAM_HEARTBEAT,
+    namespace: "side",
+    source: "camera",
+    label: "Camera",
+    level: "ERROR",
+    staleMs: 15000,
+  },
+  {
+    key: "recorder",
+    event: RECORDER_HEARTBEAT,
+    namespace: "side",
+    source: "recorder",
+    label: "Recorder",
+    level: "ERROR",
+    staleMs: 20000,
+  },
+];
+
+// Given the last-seen timestamp per stream key, returns the streams currently
+// stale at `now`. A stream that has never been seen is skipped: we can't claim
+// it is stale before its first heartbeat, which avoids false alarms at startup
+// and for streams the current UI mode never subscribes to.
+export function evaluateStaleStreams(lastSeen, now, streams = HEARTBEAT_STREAMS) {
+  const stale = {};
+  streams.forEach((stream) => {
+    const seenAt = lastSeen[stream.key];
+    if (!seenAt) return;
+    if (now - seenAt > stream.staleMs) {
+      stale[stream.key] = stream;
+    }
+  });
+  return stale;
+}

--- a/react-frontend/src/features/heartbeats/streams.test.js
+++ b/react-frontend/src/features/heartbeats/streams.test.js
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { evaluateStaleStreams } from "./streams";
+
+const streams = [
+  { key: "nav", staleMs: 15000 },
+  { key: "camera", staleMs: 15000 },
+  { key: "sensor", staleMs: 30000 },
+];
+
+test("flags only streams that have exceeded their stale window", () => {
+  const now = 100000;
+  const lastSeen = {
+    nav: now - 16000, // stale (> 15s)
+    camera: now - 5000, // fresh
+    // sensor: never seen
+  };
+
+  const stale = evaluateStaleStreams(lastSeen, now, streams);
+
+  expect(Object.keys(stale)).toEqual(["nav"]);
+});
+
+test("never-seen streams are not considered stale", () => {
+  const stale = evaluateStaleStreams({}, 100000, streams);
+  expect(stale).toEqual({});
+});
+
+test("respects per-stream thresholds", () => {
+  const now = 100000;
+  // 20s without an update: past nav's 15s window, within sensor's 30s window.
+  const lastSeen = { nav: now - 20000, sensor: now - 20000 };
+
+  const stale = evaluateStaleStreams(lastSeen, now, streams);
+
+  expect(Object.keys(stale)).toEqual(["nav"]);
+});

--- a/react-frontend/src/features/observer-ui/CameraControls.jsx
+++ b/react-frontend/src/features/observer-ui/CameraControls.jsx
@@ -5,6 +5,7 @@ import { Grid, Paper } from "@mui/material";
 import CameraControlButtons from "./CameraControlButtons";
 import LargeVideo from "../camera-controls/LargeVideo";
 import ErrorCard from "../camera-controls/ErrorCard";
+import AlertHighlight from "../system-messages/AlertHighlight";
 import { selectCamHeartbeatData } from "../camera-controls/cameraControlsSlice";
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -41,11 +42,13 @@ export default function CameraControls({ showFullCameraControls }) {
     >
       <Grid container spacing={2} sx={{ mt: -3 }}>
         <Grid item xs={9}>
-          {camHeartbeat?.focus_mode === "ERR" ? (
-            <ErrorCard />
-          ) : (
-            <LargeVideo showFullCameraControls={showFullCameraControls} />
-          )}
+          <AlertHighlight source="camera">
+            {camHeartbeat?.focus_mode === "ERR" ? (
+              <ErrorCard />
+            ) : (
+              <LargeVideo showFullCameraControls={showFullCameraControls} />
+            )}
+          </AlertHighlight>
         </Grid>
         <Grid item xs={3}>
           <Paper className={classes.paper}>

--- a/react-frontend/src/features/observer-ui/MetaDataDisplay.jsx
+++ b/react-frontend/src/features/observer-ui/MetaDataDisplay.jsx
@@ -16,6 +16,7 @@ import {
   selectCamHeartbeatData,
   selectRecorderHeartbeatData,
 } from "../camera-controls/cameraControlsSlice";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 const useStyles = makeStyles((theme) => ({
   table: {
@@ -42,7 +43,7 @@ export default function NavDataDisplay() {
     return null;
   }
   return (
-    <div>
+    <AlertHighlight source="telemetry">
       <TableContainer component={Paper}>
         <Table className={classes.table} size="small" aria-label="Nav Data">
           <TableBody>
@@ -65,6 +66,6 @@ export default function NavDataDisplay() {
           </TableBody>
         </Table>
       </TableContainer>
-    </div>
+    </AlertHighlight>
   );
 }

--- a/react-frontend/src/features/observer-ui/ObserverSideSelect.jsx
+++ b/react-frontend/src/features/observer-ui/ObserverSideSelect.jsx
@@ -6,6 +6,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import { setObserverSide } from "../camera-controls/cameraControlsSlice";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 export default function ObserverSideSelect() {
   const [value, setValue] = useState(null);
@@ -17,17 +18,19 @@ export default function ObserverSideSelect() {
   };
 
   return (
-    <FormControl variant="standard" component="fieldset">
-      <FormLabel component="legend">Select Observer Side</FormLabel>
-      <RadioGroup
-        aria-label="observerSide"
-        name="observerSide"
-        value={value}
-        onChange={handleChange}
-      >
-        <FormControlLabel value="P" control={<Radio />} label="Port" />
-        <FormControlLabel value="S" control={<Radio />} label="Starboard" />
-      </RadioGroup>
-    </FormControl>
+    <AlertHighlight source="station" display="inline-block">
+      <FormControl variant="standard" component="fieldset">
+        <FormLabel component="legend">Select Observer Side</FormLabel>
+        <RadioGroup
+          aria-label="observerSide"
+          name="observerSide"
+          value={value}
+          onChange={handleChange}
+        >
+          <FormControlLabel value="P" control={<Radio />} label="Port" />
+          <FormControlLabel value="S" control={<Radio />} label="Starboard" />
+        </RadioGroup>
+      </FormControl>
+    </AlertHighlight>
   );
 }

--- a/react-frontend/src/features/observer-ui/SensorDataDisplay.jsx
+++ b/react-frontend/src/features/observer-ui/SensorDataDisplay.jsx
@@ -3,6 +3,7 @@ import { Grid } from "@mui/material";
 // local
 import { useSocketListener } from "../../hooks/useSocket";
 import { SENSOR_HEARTBEAT } from "../../config.js";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 export default function SensorDataDisplay() {
   const [lastMessage, setLastMessage] = useState(null);
@@ -14,16 +15,18 @@ export default function SensorDataDisplay() {
   useSocketListener("/", SENSOR_HEARTBEAT, handleMessage);
 
   return (
-    <Grid container spacing={1} justifyContent="center" alignItems="center">
-      <Grid item xs>
-        T1: {lastMessage ? lastMessage?.t1 : "na"} &deg;
+    <AlertHighlight source="sensor">
+      <Grid container spacing={1} justifyContent="center" alignItems="center">
+        <Grid item xs>
+          T1: {lastMessage ? lastMessage?.t1 : "na"} &deg;
+        </Grid>
+        <Grid item xs>
+          T2: {lastMessage ? lastMessage?.t2 : "na"} &deg;
+        </Grid>
+        <Grid item xs>
+          T3: {lastMessage ? lastMessage?.t3 : "na"} &deg;
+        </Grid>
       </Grid>
-      <Grid item xs>
-        T2: {lastMessage ? lastMessage?.t2 : "na"} &deg;
-      </Grid>
-      <Grid item xs>
-        T3: {lastMessage ? lastMessage?.t3 : "na"} &deg;
-      </Grid>
-    </Grid>
+    </AlertHighlight>
   );
 }

--- a/react-frontend/src/features/pilot-ui/CameraControlContainer.jsx
+++ b/react-frontend/src/features/pilot-ui/CameraControlContainer.jsx
@@ -18,6 +18,7 @@ import { useCameraCommandEmitter } from "../../hooks/useCameraCommandEmitter";
 import useIsOwner from "../../hooks/useIsOwner";
 import RecordingStatusChip from "./RecordingStatusChip";
 import ErrorCard from "../camera-controls/ErrorCard";
+import AlertHighlight from "../system-messages/AlertHighlight";
 import {
   changeActiveCamera,
   selectActiveCamera,
@@ -121,7 +122,9 @@ export default function CameraControlContainer() {
           <LargeVideo showFullCameraControls={true} />
         </Grid>
         <Grid item xs={3}>
-          <div className={classes.controlsBox}>{renderDynamicGridBox()}</div>
+          <AlertHighlight source={["command", "camera"]}>
+            <div className={classes.controlsBox}>{renderDynamicGridBox()}</div>
+          </AlertHighlight>
         </Grid>
       </Grid>
 

--- a/react-frontend/src/features/pilot-ui/ProcessingStatusChip.jsx
+++ b/react-frontend/src/features/pilot-ui/ProcessingStatusChip.jsx
@@ -8,6 +8,7 @@ import DoneIcon from "@mui/icons-material/Done";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 // local imports
 import { selectRecorderHeartbeatData } from "../camera-controls/cameraControlsSlice";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -47,12 +48,14 @@ export default function ProcessingStatusChip() {
   }, [lastMessage]);
   return (
     <div className={classes.root}>
-      <Chip
-        icon={isProcessingComplete ? <DoneIcon /> : <HourglassEmptyIcon />}
-        label={isProcessingComplete ? "Processing Complete" : "Processing..."}
-        color="default"
-        className={chipStyle}
-      />
+      <AlertHighlight source="capture" display="inline-flex">
+        <Chip
+          icon={isProcessingComplete ? <DoneIcon /> : <HourglassEmptyIcon />}
+          label={isProcessingComplete ? "Processing Complete" : "Processing..."}
+          color="default"
+          className={chipStyle}
+        />
+      </AlertHighlight>
     </div>
   );
 }

--- a/react-frontend/src/features/pilot-ui/RecordingStatusChip.jsx
+++ b/react-frontend/src/features/pilot-ui/RecordingStatusChip.jsx
@@ -10,6 +10,7 @@ import {
   selectActiveCameraConfig,
   selectRecorderHeartbeatData,
 } from "../camera-controls/cameraControlsSlice";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -55,12 +56,14 @@ export default function RecordingStatusChip() {
   }, [lastMessage, activeCameraConfig]);
   return (
     <div>
-      <Chip
-        icon={isRecording ? <VideocamIcon /> : <VideocamOffIcon />}
-        label={isRecording ? "RECORDING" : "NOT RECORDING"}
-        color="default"
-        className={chipStyle}
-      />
+      <AlertHighlight source="recorder" display="inline-flex">
+        <Chip
+          icon={isRecording ? <VideocamIcon /> : <VideocamOffIcon />}
+          label={isRecording ? "RECORDING" : "NOT RECORDING"}
+          color="default"
+          className={chipStyle}
+        />
+      </AlertHighlight>
     </div>
   );
 }

--- a/react-frontend/src/features/pilot-ui/RouterControlContainer.jsx
+++ b/react-frontend/src/features/pilot-ui/RouterControlContainer.jsx
@@ -16,6 +16,7 @@ import {
 } from "../../config.js";
 import PilotRecordButton from "../camera-controls/PilotRecordButton";
 import { selectActiveCamera, selectObserverSide } from "../camera-controls/cameraControlsSlice";
+import AlertHighlight from "../system-messages/AlertHighlight";
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -154,7 +155,9 @@ export default function RouterControlContainer() {
         </Grid>
       </Box>
       <Box mt={3}>
-        <RouterControls />
+        <AlertHighlight source="command">
+          <RouterControls />
+        </AlertHighlight>
       </Box>
     </>
   );

--- a/react-frontend/src/features/system-messages/AlertHighlight.jsx
+++ b/react-frontend/src/features/system-messages/AlertHighlight.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import Box from "@mui/material/Box";
+import Tooltip from "@mui/material/Tooltip";
+import {
+  selectActiveAlertSources,
+  SYSTEM_MESSAGE_PRIORITY,
+} from "./systemMessagesSlice";
+import { LEVEL_META, SOURCE_META } from "./systemMessageUi";
+
+// Wraps a control and draws a subtle pulsing ring in the alert colour when there
+// is an unacknowledged WARN+ system message whose `source` matches, pointing the
+// operator at where an issue originates. `source` may be a single source or an
+// array (e.g. a control affected by both command failures and heartbeat loss),
+// in which case the worst active level wins. When nothing is active it renders
+// the children inside a plain Box, so there is no layout shift either way. The
+// ring uses box-shadow (painted outside the box) rather than a border, so it
+// never nudges surrounding layout.
+export default function AlertHighlight({
+  source,
+  children,
+  display = "block",
+  sx,
+  ...rest
+}) {
+  const activeSources = useSelector(selectActiveAlertSources);
+
+  const sources = Array.isArray(source) ? source : [source];
+  let level = null;
+  let activeSource = null;
+  sources.forEach((candidate) => {
+    const candidateLevel = activeSources[candidate];
+    if (
+      candidateLevel &&
+      (level === null ||
+        SYSTEM_MESSAGE_PRIORITY[candidateLevel] > SYSTEM_MESSAGE_PRIORITY[level])
+    ) {
+      level = candidateLevel;
+      activeSource = candidate;
+    }
+  });
+
+  if (!level) {
+    return (
+      <Box display={display} sx={sx} {...rest}>
+        {children}
+      </Box>
+    );
+  }
+
+  const { color, label: levelLabel } = LEVEL_META[level];
+  const sourceLabel = SOURCE_META[activeSource]?.label || activeSource;
+
+  return (
+    <Tooltip title={`${sourceLabel}: ${levelLabel} — see system messages`}>
+      <Box
+        display={display}
+        sx={{
+          borderRadius: 1,
+          boxShadow: `0 0 0 2px ${color}`,
+          animation: "alvinAlertPulse 1.8s ease-in-out infinite",
+          "@keyframes alvinAlertPulse": {
+            "0%, 100%": { boxShadow: `0 0 0 2px ${color}55` },
+            "50%": { boxShadow: `0 0 0 3px ${color}` },
+          },
+          "@media (prefers-reduced-motion: reduce)": {
+            animation: "none",
+            boxShadow: `0 0 0 2px ${color}`,
+          },
+          ...sx,
+        }}
+        {...rest}
+      >
+        {children}
+      </Box>
+    </Tooltip>
+  );
+}

--- a/react-frontend/src/features/system-messages/systemMessageUi.js
+++ b/react-frontend/src/features/system-messages/systemMessageUi.js
@@ -27,6 +27,19 @@ export const LEVEL_META = {
   },
 };
 
+// Human-readable labels for the `source` field Suboptica stamps on each alert
+// (see suboptica reduce.py). Used to caption control highlights so an operator
+// knows which subsystem a flagged control relates to.
+export const SOURCE_META = {
+  command: { label: "Device command" },
+  recorder: { label: "Recorder" },
+  capture: { label: "Image capture" },
+  telemetry: { label: "Telemetry" },
+  station: { label: "Station view" },
+  camera: { label: "Camera" },
+  sensor: { label: "Sensor" },
+};
+
 export const IDLE_META = {
   color: "#78909c",
   Icon: NotificationsNoneIcon,

--- a/react-frontend/src/features/system-messages/systemMessagesSlice.js
+++ b/react-frontend/src/features/system-messages/systemMessagesSlice.js
@@ -152,3 +152,31 @@ export const selectWorstSystemMessageLevel = createSelector(
       return worstLevel;
     }, null)
 );
+
+// Lowest level worth drawing attention to on a control. INFO messages stay in
+// the notification panel only, so highlighting stays quiet during normal ops.
+const HIGHLIGHT_MIN_PRIORITY = SYSTEM_MESSAGE_PRIORITY.WARN;
+
+// Maps each message `source` to the worst unread level currently affecting it,
+// e.g. { recorder: "ERROR", telemetry: "WARN" }. Controls subscribe to this to
+// highlight where an issue originates; the entry clears once messages are read.
+export const selectActiveAlertSources = createSelector(
+  selectUnreadSystemMessages,
+  (messages) =>
+    messages.reduce((sources, message) => {
+      if (!message.source) return sources;
+      if (SYSTEM_MESSAGE_PRIORITY[message.level] < HIGHLIGHT_MIN_PRIORITY) {
+        return sources;
+      }
+
+      const current = sources[message.source];
+      if (
+        current === undefined ||
+        SYSTEM_MESSAGE_PRIORITY[message.level] > SYSTEM_MESSAGE_PRIORITY[current]
+      ) {
+        sources[message.source] = message.level;
+      }
+
+      return sources;
+    }, {})
+);

--- a/react-frontend/src/features/system-messages/systemMessagesSlice.test.js
+++ b/react-frontend/src/features/system-messages/systemMessagesSlice.test.js
@@ -4,6 +4,7 @@ import reducer, {
   dismissReadSystemMessages,
   markAllSystemMessagesRead,
   removeExpiredSystemMessages,
+  selectActiveAlertSources,
   selectSystemMessages,
   selectUnreadSystemMessageCount,
   selectUnreadSystemMessageCounts,
@@ -115,6 +116,63 @@ test("expires ttl messages but keeps sticky messages", () => {
   expect(selectSystemMessages(rootState(state)).map((message) => message.id)).toEqual([
     "sticky-1",
   ]);
+});
+
+test("tracks active alert sources by worst unread level", () => {
+  let state = reducer(undefined, { type: "@@INIT" });
+
+  // INFO is below the highlight threshold and should be ignored.
+  state = reducer(
+    state,
+    addSystemMessage(
+      {
+        correlation_id: "info-recorder",
+        timestamp: "2026-06-15T12:00:00Z",
+        message: "Recording started outside Suboptica",
+        level: "INFO",
+        source: "recorder",
+      },
+      1000
+    )
+  );
+
+  state = reducer(
+    state,
+    addSystemMessage(
+      {
+        correlation_id: "warn-telemetry",
+        timestamp: "2026-06-15T12:00:01Z",
+        message: "ADN dive number mismatch",
+        level: "WARN",
+        source: "telemetry",
+      },
+      1000
+    )
+  );
+
+  state = reducer(
+    state,
+    addSystemMessage(
+      {
+        correlation_id: "error-recorder",
+        timestamp: "2026-06-15T12:00:02Z",
+        message: "Recorder fault",
+        level: "ERROR",
+        source: "recorder",
+      },
+      1000
+    )
+  );
+
+  // Worst level wins per source; sub-threshold and sourceless messages drop out.
+  expect(selectActiveAlertSources(rootState(state))).toEqual({
+    telemetry: "WARN",
+    recorder: "ERROR",
+  });
+
+  // Acknowledging clears the highlights.
+  state = reducer(state, markAllSystemMessagesRead());
+  expect(selectActiveAlertSources(rootState(state))).toEqual({});
 });
 
 test("refreshes messages with the same correlation id", () => {


### PR DESCRIPTION
## Summary

Makes Suboptica system messages actionable on a **per-message basis** rather than only incrementing the notification bar, and adds **client-side heartbeat staleness detection**. Builds on the existing notification bell / pilot SYSTEM tab work already on this branch.

### Source-driven control highlighting
- New `selectActiveAlertSources` selector maps each unread **WARN+** message's `source` to its worst level.
- New reusable `AlertHighlight` wrapper draws a subtle pulsing ring (box-shadow, no layout shift; respects `prefers-reduced-motion`) in the severity colour while a matching alert is unacknowledged, with a tooltip. Accepts one source or several (worst level wins).
- Wired the Suboptica sources to their natural controls:
  - `recorder` → recording status chip
  - `capture` → processing status chip
  - `command` → camera & router controls
  - `telemetry` → dive metadata table
  - `station` → observer-side select

### Heartbeat staleness watchdog (client-side)
- `HeartbeatWatchdog` (mounted in `App.jsx`, both modes) tracks last-seen time per stream — **nav, sensor, camera, recorder** — and raises a single WARN/ERROR system message when one goes quiet, clearing it on recovery. Stale streams light up the matching control through the same `AlertHighlight` path.
- Never-seen streams are skipped, so there are no startup/cross-mode false alarms.
- Losing the imaging-server heartbeats (camera/recorder) also drives the previously **dead** `SocketErrorChip` connection indicator.

### Tests
- `systemMessagesSlice.test.js`: active-source selector (worst-level-per-source, INFO/sourceless ignored, clears on read).
- `heartbeats/streams.test.js`: staleness evaluator (per-stream thresholds, never-seen handling).
- Full suite green (70 tests); production build clean.

## Notes / follow-ups
- **Staleness thresholds are placeholders** (nav 15s / camera 15s / recorder 20s / sensor 30s) since I couldn't find the real heartbeat cadence — all centralized in `features/heartbeats/streams.js`. Please confirm real intervals.
- This is the connection/stream-loss layer; per-device "camera X died" semantics would be a complementary Suboptica-side watchdog (`last_seen_at` already exists there) — deliberately out of scope here.
- Unrelated local edits in the working tree (`package.json` dev host, `public/configEnv.js`, `AGENTS.md`) were intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)