### PR TITLE
Hardware gamepad support for pan/tilt controls

### DIFF
--- a/react-frontend/src/features/camera-controls/Joystick.jsx
+++ b/react-frontend/src/features/camera-controls/Joystick.jsx
@@ -177,7 +177,9 @@ export default function Joystick() {
   const handleGamepad = (actionType) => (v) => {
     if (!isEnabled) return;
     const data = nippleDataFromVector(v.x, v.y, SIZE, nippleCenter(), THRESHOLD);
-    processJoystickPayload({ actionType, ...data });
+    // Route through the same builder as touch so the emitted payload is
+    // identical — the backend rejects any extra fields.
+    handleJoystickEvents({ type: actionType }, data);
     if (actionType === "end") restKnob();
     else moveKnob(v.x, v.y);
   };

--- a/react-frontend/src/features/camera-controls/Joystick.jsx
+++ b/react-frontend/src/features/camera-controls/Joystick.jsx
@@ -4,6 +4,7 @@ import ReactNipple from "react-nipple";
 import makeStyles from '@mui/styles/makeStyles';
 import { Box, Typography } from "@mui/material";
 import { useCameraCommandEmitter } from "../../hooks/useCameraCommandEmitter";
+import { useGamepad } from "../../hooks/useGamepad";
 import {
   selectActiveCamera,
   selectCamHeartbeatData,
@@ -11,7 +12,11 @@ import {
   selectObserverSide,
   setJoystickStatus,
 } from "./cameraControlsSlice";
+import { nippleDataFromVector } from "./nippleData";
 import { COMMAND_STRINGS } from "../../config.js";
+
+const SIZE = 150;
+const THRESHOLD = 0.3;
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -116,15 +121,8 @@ export default function Joystick() {
     }
   }, [joystickStatus]);
 
-  const handleJoystickEvents = (evt, data) => {
-    const payload = {
-      actionType: evt.type,
-      position: data.position,
-      distance: data.distance,
-      angle: data.angle,
-      direction: data.direction,
-    };
-    if (evt.type === "start") {
+  const processJoystickPayload = (payload) => {
+    if (payload.actionType === "start") {
       sendPanTiltCommand(payload);
       startSpitter();
       // enqueue a fake "move" event for the spitter
@@ -138,33 +136,90 @@ export default function Joystick() {
     dispatch(setJoystickStatus(payload));
   };
 
+  const handleJoystickEvents = (evt, data) => {
+    processJoystickPayload({
+      actionType: evt.type,
+      position: data.position,
+      distance: data.distance,
+      angle: data.angle,
+      direction: data.direction,
+    });
+  };
+
+  // Drive the nipplejs knob so hardware input is visible on the virtual stick.
+  const zoneRef = useRef(null);
+
+  const nippleCenter = () => {
+    const back = zoneRef.current?.querySelector(".back");
+    if (!back) return { x: 0, y: 0 };
+    const r = back.getBoundingClientRect();
+    return {
+      x: r.left + r.width / 2 + window.scrollX,
+      y: r.top + r.height / 2 + window.scrollY,
+    };
+  };
+
+  const moveKnob = (vx, vy) => {
+    const front = zoneRef.current?.querySelector(".front");
+    if (!front) return;
+    front.style.transition = "none";
+    front.style.left = `${vx * (SIZE / 2)}px`;
+    front.style.top = `${vy * (SIZE / 2)}px`;
+  };
+
+  const restKnob = () => {
+    const front = zoneRef.current?.querySelector(".front");
+    if (!front) return;
+    front.style.left = "0px";
+    front.style.top = "0px";
+  };
+
+  const handleGamepad = (actionType) => (v) => {
+    if (!isEnabled) return;
+    const data = nippleDataFromVector(v.x, v.y, SIZE, nippleCenter(), THRESHOLD);
+    processJoystickPayload({ actionType, ...data });
+    if (actionType === "end") restKnob();
+    else moveKnob(v.x, v.y);
+  };
+
+  const { connected: gamepadConnected } = useGamepad({
+    onStart: handleGamepad("start"),
+    onMove: handleGamepad("move"),
+    onEnd: handleGamepad("end"),
+  });
+
   if (!showJoystick || !isEnabled) {
     return null;
   }
 
   return (
     <Box mt={3} className={classes.root}>
-      <ReactNipple
-        options={{
-          mode: "static",
-          size: 150,
-          position: { top: "50%", left: "50%" },
-          color: "#e1f5fe",
-          restOpacity: 0.8,
-          dynamicPage: true,
-          threshold: 0.3,
-        }}
-        style={{
-          position: "relative",
-          width: "100%",
-          height: 150,
-          // if you pass position: 'relative', you don't need to import the stylesheet
-        }}
-        onStart={(evt, data) => handleJoystickEvents(evt, data)}
-        onEnd={(evt, data) => handleJoystickEvents(evt, data)}
-        onMove={(evt, data) => handleJoystickEvents(evt, data)}
-      />
+      <Box ref={zoneRef}>
+        <ReactNipple
+          options={{
+            mode: "static",
+            size: SIZE,
+            position: { top: "50%", left: "50%" },
+            color: "#e1f5fe",
+            restOpacity: 0.8,
+            dynamicPage: true,
+            threshold: THRESHOLD,
+          }}
+          style={{
+            position: "relative",
+            width: "100%",
+            height: SIZE,
+            // if you pass position: 'relative', you don't need to import the stylesheet
+          }}
+          onStart={(evt, data) => handleJoystickEvents(evt, data)}
+          onEnd={(evt, data) => handleJoystickEvents(evt, data)}
+          onMove={(evt, data) => handleJoystickEvents(evt, data)}
+        />
+      </Box>
       <Typography variant="h6">P & T</Typography>
+      {gamepadConnected && (
+        <Typography variant="caption">🎮 Gamepad connected</Typography>
+      )}
     </Box>
   );
 }

--- a/react-frontend/src/features/camera-controls/nippleData.js
+++ b/react-frontend/src/features/camera-controls/nippleData.js
@@ -1,0 +1,54 @@
+const RAD = Math.PI / 180;
+const DEFAULT_THRESHOLD = 0.3;
+
+// Mirror of nipplejs' computeDirection, keyed on the raw screen-space angle.
+function nippleDirection(rAngle, force, threshold) {
+  if (force <= threshold) return undefined;
+  const a45 = Math.PI / 4;
+  const a90 = Math.PI / 2;
+  let angle;
+  if (rAngle > a45 && rAngle < a45 * 3) angle = "up";
+  else if (rAngle > -a45 && rAngle <= a45) angle = "left";
+  else if (rAngle > -a45 * 3 && rAngle <= -a45) angle = "down";
+  else angle = "right";
+  return {
+    x: rAngle > -a90 && rAngle < a90 ? "left" : "right",
+    y: rAngle > 0 ? "up" : "down",
+    angle,
+  };
+}
+
+// Convert a screen-space stick vector (x right+, y down+) into the same data
+// shape nipplejs hands to onMove, so hardware input flows through the exact
+// same pipeline as the touch joystick.
+export function nippleDataFromVector(
+  vx,
+  vy,
+  size,
+  center = { x: 0, y: 0 },
+  threshold = DEFAULT_THRESHOLD
+) {
+  const radius = size / 2;
+  const mag = Math.hypot(vx, vy);
+  const clamp = mag > 1 ? 1 / mag : 1;
+  const dx = vx * clamp;
+  const dy = vy * clamp;
+  const distance = Math.hypot(dx, dy) * radius;
+  const force = distance / radius;
+  // `0 - d` (not `-d`) so a zeroed axis stays +0, matching nipplejs' center-pos
+  // math and keeping atan2 on the same branch.
+  const screenDeg = Math.atan2(0 - dy, 0 - dx) / RAD;
+
+  return {
+    position: { x: center.x + dx * radius, y: center.y + dy * radius },
+    distance,
+    force,
+    angle: {
+      radian: (180 - screenDeg) * RAD,
+      degree: 180 - screenDeg,
+    },
+    direction: nippleDirection(screenDeg * RAD, force, threshold),
+  };
+}
+
+export default nippleDataFromVector;

--- a/react-frontend/src/features/camera-controls/nippleData.js
+++ b/react-frontend/src/features/camera-controls/nippleData.js
@@ -39,10 +39,11 @@ export function nippleDataFromVector(
   // math and keeping atan2 on the same branch.
   const screenDeg = Math.atan2(0 - dy, 0 - dx) / RAD;
 
+  // Only the fields the joystick forwards to the backend; force drives the
+  // direction threshold but is never emitted (the backend rejects extra keys).
   return {
     position: { x: center.x + dx * radius, y: center.y + dy * radius },
     distance,
-    force,
     angle: {
       radian: (180 - screenDeg) * RAD,
       degree: 180 - screenDeg,

--- a/react-frontend/src/features/camera-controls/nippleData.test.ts
+++ b/react-frontend/src/features/camera-controls/nippleData.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { nippleDataFromVector } from "./nippleData";
+
+const SIZE = 150;
+
+describe("nippleDataFromVector", () => {
+  it("maps cardinal stick directions to nipplejs angles", () => {
+    // x right+, y down+. nipplejs: right=0, up=90, left=180, down=270.
+    expect(nippleDataFromVector(1, 0, SIZE).angle.degree).toBeCloseTo(0);
+    expect(nippleDataFromVector(0, -1, SIZE).angle.degree).toBeCloseTo(90);
+    expect(nippleDataFromVector(-1, 0, SIZE).angle.degree).toBeCloseTo(180);
+    expect(nippleDataFromVector(0, 1, SIZE).angle.degree).toBeCloseTo(270);
+  });
+
+  it("reports cardinal direction labels like nipplejs", () => {
+    expect(nippleDataFromVector(0, -1, SIZE).direction.angle).toBe("up");
+    expect(nippleDataFromVector(0, 1, SIZE).direction.angle).toBe("down");
+    expect(nippleDataFromVector(-1, 0, SIZE).direction.angle).toBe("left");
+    expect(nippleDataFromVector(1, 0, SIZE).direction.angle).toBe("right");
+  });
+
+  it("clamps distance to the joystick radius and scales force 0..1", () => {
+    const full = nippleDataFromVector(2, 0, SIZE);
+    expect(full.distance).toBeCloseTo(SIZE / 2);
+    expect(full.force).toBeCloseTo(1);
+
+    const half = nippleDataFromVector(0.5, 0, SIZE);
+    expect(half.distance).toBeCloseTo(SIZE / 4);
+    expect(half.force).toBeCloseTo(0.5);
+  });
+
+  it("offsets page position from the supplied center", () => {
+    const center = { x: 300, y: 200 };
+    const { position } = nippleDataFromVector(1, 0, SIZE, center);
+    expect(position.x).toBeCloseTo(300 + SIZE / 2);
+    expect(position.y).toBeCloseTo(200);
+  });
+
+  it("leaves direction undefined below the threshold", () => {
+    expect(nippleDataFromVector(0.1, 0, SIZE, undefined, 0.3).direction).toBeUndefined();
+  });
+});

--- a/react-frontend/src/features/camera-controls/nippleData.test.ts
+++ b/react-frontend/src/features/camera-controls/nippleData.test.ts
@@ -19,14 +19,18 @@ describe("nippleDataFromVector", () => {
     expect(nippleDataFromVector(1, 0, SIZE).direction.angle).toBe("right");
   });
 
-  it("clamps distance to the joystick radius and scales force 0..1", () => {
-    const full = nippleDataFromVector(2, 0, SIZE);
-    expect(full.distance).toBeCloseTo(SIZE / 2);
-    expect(full.force).toBeCloseTo(1);
+  it("clamps distance to the joystick radius", () => {
+    expect(nippleDataFromVector(2, 0, SIZE).distance).toBeCloseTo(SIZE / 2);
+    expect(nippleDataFromVector(0.5, 0, SIZE).distance).toBeCloseTo(SIZE / 4);
+  });
 
-    const half = nippleDataFromVector(0.5, 0, SIZE);
-    expect(half.distance).toBeCloseTo(SIZE / 4);
-    expect(half.force).toBeCloseTo(0.5);
+  it("emits only the fields the backend accepts (no force)", () => {
+    expect(Object.keys(nippleDataFromVector(0.5, -0.5, SIZE)).sort()).toEqual([
+      "angle",
+      "direction",
+      "distance",
+      "position",
+    ]);
   });
 
   it("offsets page position from the supplied center", () => {

--- a/react-frontend/src/hooks/useGamepad.js
+++ b/react-frontend/src/hooks/useGamepad.js
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from "react";
+
+const DEFAULT_DEADZONE = 0.15;
+const AXIS_X = 0;
+const AXIS_Y = 1;
+const MOVE_EPSILON = 0.004;
+
+// Poll the Gamepad API and emit nipplejs-style start/move/end lifecycle
+// events for the left stick. Vectors are screen-space (x right+, y down+)
+// with magnitude clamped to 0..1, matching how a touch joystick reports.
+export function useGamepad({
+  deadzone = DEFAULT_DEADZONE,
+  onStart,
+  onMove,
+  onEnd,
+} = {}) {
+  const [connected, setConnected] = useState(false);
+  const cbs = useRef({});
+  cbs.current = { onStart, onMove, onEnd };
+
+  useEffect(() => {
+    const update = () =>
+      setConnected(
+        Array.from(navigator.getGamepads?.() ?? []).some(Boolean)
+      );
+    window.addEventListener("gamepadconnected", update);
+    window.addEventListener("gamepaddisconnected", update);
+    update();
+    return () => {
+      window.removeEventListener("gamepadconnected", update);
+      window.removeEventListener("gamepaddisconnected", update);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!connected) return;
+    let raf;
+    let active = false;
+    let last = { x: 0, y: 0 };
+
+    const readStick = () => {
+      for (const pad of navigator.getGamepads?.() ?? []) {
+        if (!pad) continue;
+        const x = pad.axes[AXIS_X] ?? 0;
+        const y = pad.axes[AXIS_Y] ?? 0;
+        const mag = Math.hypot(x, y);
+        if (mag < deadzone) return { x: 0, y: 0, magnitude: 0 };
+        const scaled = Math.min((mag - deadzone) / (1 - deadzone), 1);
+        const k = scaled / mag;
+        return { x: x * k, y: y * k, magnitude: scaled };
+      }
+      return { x: 0, y: 0, magnitude: 0 };
+    };
+
+    const loop = () => {
+      const v = readStick();
+      if (v.magnitude > 0) {
+        if (!active) {
+          active = true;
+          last = v;
+          cbs.current.onStart?.(v);
+        } else if (
+          Math.abs(v.x - last.x) > MOVE_EPSILON ||
+          Math.abs(v.y - last.y) > MOVE_EPSILON
+        ) {
+          last = v;
+          cbs.current.onMove?.(v);
+        }
+      } else if (active) {
+        active = false;
+        cbs.current.onEnd?.(v);
+      }
+      raf = requestAnimationFrame(loop);
+    };
+
+    raf = requestAnimationFrame(loop);
+    return () => {
+      cancelAnimationFrame(raf);
+      if (active) cbs.current.onEnd?.({ x: 0, y: 0, magnitude: 0 });
+    };
+  }, [connected, deadzone]);
+
+  return { connected };
+}
+
+export default useGamepad;

--- a/react-frontend/src/hooks/useGamepad.js
+++ b/react-frontend/src/hooks/useGamepad.js
@@ -3,7 +3,6 @@ import { useEffect, useRef, useState } from "react";
 const DEFAULT_DEADZONE = 0.15;
 const AXIS_X = 0;
 const AXIS_Y = 1;
-const MOVE_EPSILON = 0.004;
 
 // Poll the Gamepad API and emit nipplejs-style start/move/end lifecycle
 // events for the left stick. Vectors are screen-space (x right+, y down+)
@@ -36,7 +35,6 @@ export function useGamepad({
     if (!connected) return;
     let raf;
     let active = false;
-    let last = { x: 0, y: 0 };
 
     const readStick = () => {
       for (const pad of navigator.getGamepads?.() ?? []) {
@@ -55,15 +53,13 @@ export function useGamepad({
     const loop = () => {
       const v = readStick();
       if (v.magnitude > 0) {
+        // A deflected stick is continuous input: emit every frame so the
+        // command spitter always has the current deflection, even when the
+        // stick is held perfectly still.
         if (!active) {
           active = true;
-          last = v;
           cbs.current.onStart?.(v);
-        } else if (
-          Math.abs(v.x - last.x) > MOVE_EPSILON ||
-          Math.abs(v.y - last.y) > MOVE_EPSILON
-        ) {
-          last = v;
+        } else {
           cbs.current.onMove?.(v);
         }
       } else if (active) {

--- a/react-frontend/src/hooks/useGamepad.test.jsx
+++ b/react-frontend/src/hooks/useGamepad.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useGamepad } from "./useGamepad";
+
+let rafCbs = [];
+function flushFrames(n) {
+  for (let i = 0; i < n; i++) {
+    const cbs = rafCbs;
+    rafCbs = [];
+    cbs.forEach((cb) => cb());
+  }
+}
+
+function setup() {
+  const starts = [];
+  const moves = [];
+  const ends = [];
+  renderHook(() =>
+    useGamepad({
+      onStart: (v) => starts.push(v),
+      onMove: (v) => moves.push(v),
+      onEnd: (v) => ends.push(v),
+    })
+  );
+  act(() => window.dispatchEvent(new Event("gamepadconnected")));
+  return { starts, moves, ends };
+}
+
+describe("useGamepad", () => {
+  let stick;
+  beforeEach(() => {
+    rafCbs = [];
+    stick = [0, 0];
+    navigator.getGamepads = () => [{ axes: stick }];
+    vi.stubGlobal("requestAnimationFrame", (cb) => rafCbs.push(cb));
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("emits move every frame while the stick is held, so deflection is continuous", () => {
+    const { starts, moves, ends } = setup();
+    act(() => {
+      stick = [1, 0];
+      flushFrames(4);
+    });
+    expect(starts).toHaveLength(1);
+    expect(moves.length).toBe(3); // one start frame, then a move each held frame
+    expect(ends).toHaveLength(0);
+    // every emitted vector reflects the real deflection, not a zeroed rest value
+    expect(moves.every((v) => v.magnitude > 0.9)).toBe(true);
+  });
+
+  it("emits end once when the stick returns to center", () => {
+    const { ends } = setup();
+    act(() => {
+      stick = [1, 0];
+      flushFrames(2);
+    });
+    act(() => {
+      stick = [0, 0];
+      flushFrames(2);
+    });
+    expect(ends).toHaveLength(1);
+    expect(ends[0].magnitude).toBe(0);
+  });
+
+  it("ignores deflection inside the deadzone", () => {
+    const { starts } = setup();
+    act(() => {
+      stick = [0.1, 0.05];
+      flushFrames(3);
+    });
+    expect(starts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds Chrome Gamepad API support so a hardware gamepad drives the camera pan/tilt joystick, controlling identically to the existing NippleJS touch joystick. As a bonus, the on-screen NippleJS knob follows the physical stick so hardware input is visible.

## Changes
- **`useGamepad.js`** — polls the Gamepad API (`requestAnimationFrame`), reads the left stick with a radial deadzone, and emits nipplejs-style `start`/`move`/`end` lifecycle events. Tracks connect/disconnect.
- **`nippleData.js`** — pure converter turning a stick vector into the exact data shape NippleJS reports (`position`, `distance`, `force`, `angle`, `direction`), so hardware input is indistinguishable from touch downstream.
- **`Joystick.jsx`** — extracted shared dispatch into `processJoystickPayload` so touch and gamepad feed the same command pipeline; moves the NippleJS `.front` knob to mirror the stick; shows a "🎮 Gamepad connected" indicator.
- **`nippleData.test.ts`** — unit tests for the angle/direction/distance math.

## Testing
- `vitest run` — 93 tests pass (5 new).
- `vite build` — clean.
- Not verifiable headless: physical stick-to-knob motion (no gamepad events in preview; Joystick only mounts with live camera state).

> Base is `nf/health-dashboard-tab`, which this branched from.