### PR TITLE
Target encoder REST paths by _enc keys

### DIFF
--- a/react-frontend/src/config.js
+++ b/react-frontend/src/config.js
@@ -87,3 +87,14 @@ export const VIDEO_STREAM_CONFIG = {
   stbdRecordVideo: envSettings.STBD_RECORDER_VIDEO,
   pilotVideo: envSettings.PILOT_VIDEO,
 };
+
+// Suboptica encoder keys, used as the {name} in v1.5 /encoder/{name} REST
+// paths. Distinct from the video stream names above (MediaMTX paths) and fixed
+// by the Suboptica topology, so they live here rather than in configEnv.
+export const ENCODER_KEYS = {
+  portObserver: "port_mon_enc",
+  stbdObserver: "stbd_mon_enc",
+  pilot: "pilot_mon_enc",
+  portRecorder: "port_rec_enc",
+  stbdRecorder: "stbd_rec_enc",
+};

--- a/react-frontend/src/features/pilot-ui/RouterControlContainer.jsx
+++ b/react-frontend/src/features/pilot-ui/RouterControlContainer.jsx
@@ -11,6 +11,7 @@ import MiniVideoHeader from "./MiniVideoHeader";
 import EncoderActions from "./EncoderActions";
 import {
   VIDEO_STREAM_CONFIG,
+  ENCODER_KEYS,
   COMMAND_STRINGS,
   WS_SERVER_NAMESPACE_PORT,
   WS_SERVER_NAMESPACE_STARBOARD,
@@ -93,7 +94,7 @@ export default function RouterControlContainer() {
             }
             key="video1"
           />
-          <EncoderActions name={VIDEO_STREAM_CONFIG.portRecordVideo} />
+          <EncoderActions name={ENCODER_KEYS.portRecorder} />
         </Grid>
         <Grid item xs>
           <MiniVideo
@@ -108,7 +109,7 @@ export default function RouterControlContainer() {
             }
             key="video0"
           />
-          <EncoderActions name={VIDEO_STREAM_CONFIG.portObserverVideo} />
+          <EncoderActions name={ENCODER_KEYS.portObserver} />
         </Grid>
 
         <Grid item xs>
@@ -124,7 +125,7 @@ export default function RouterControlContainer() {
             }
             key="video2"
           />
-          <EncoderActions name={VIDEO_STREAM_CONFIG.pilotVideo} />
+          <EncoderActions name={ENCODER_KEYS.pilot} />
         </Grid>
 
         <Grid item xs>
@@ -140,7 +141,7 @@ export default function RouterControlContainer() {
             }
             key="video3"
           />
-          <EncoderActions name={VIDEO_STREAM_CONFIG.stbdObserverVideo} />
+          <EncoderActions name={ENCODER_KEYS.stbdObserver} />
         </Grid>
         <Grid item xs>
           <MiniVideo
@@ -155,7 +156,7 @@ export default function RouterControlContainer() {
             }
             key="video4"
           />
-          <EncoderActions name={VIDEO_STREAM_CONFIG.stbdRecordVideo} />
+          <EncoderActions name={ENCODER_KEYS.stbdRecorder} />
         </Grid>
       </Grid>
 

--- a/react-frontend/src/features/system-health/healthFixture.js
+++ b/react-frontend/src/features/system-health/healthFixture.js
@@ -119,7 +119,7 @@ const HEALTH_FIXTURE = {
       ],
     },
     {
-      id: "port_mon",
+      id: "port_mon_enc",
       label: "port mon encoder",
       kind: "encoder",
       station: "port",


### PR DESCRIPTION
## Why
Suboptica renamed its encoder config keys to `*_enc` (e.g. `port_rec` -> `port_rec_enc`) so they read as encoders. Those keys are the `{name}` in the v1.5 `/encoder/{name}` REST paths this UI posts to.

Previously `EncoderActions` reused `VIDEO_STREAM_CONFIG.*` (the MediaMTX stream names) as the encoder name. Those can't carry the `_enc` suffix, and they already diverged from the encoder keys in production config (`port_obs` vs `port_mon`), so observer-encoder restart was mistargeted there.

## What
- Add `ENCODER_KEYS` in `config.js`, decoupled from the video stream names and fixed by the Suboptica topology.
- `RouterControlContainer` passes `ENCODER_KEYS.*` to `EncoderActions` for the restart/reboot POSTs.
- Update the system-health fixture encoder id to `port_mon_enc` to mirror the real snapshot.

Paired with suboptica `nf/encoder-keys`.

`npm run test` (88 passing) and `npm run build` both pass.