### PR TITLE
pilot alerts: trash clears all, enlarge read/trash icons

### DIFF
--- a/compose/Dockerfile
+++ b/compose/Dockerfile
@@ -15,12 +15,14 @@ WORKDIR /app
 # && update-ca-certificates
 ARG npm_config_cafile=/etc/ssl/certs/ca-certificates.crt 
 
-# Update NPM to latest version
-RUN npm i npm@latest -g
+# Pinned: npm@latest let a new npm release change the build under us. Bump
+# deliberately, and rebuild once when you do.
+RUN npm i npm@12.0.2 -g
 
-# Install all node packages
+# Install the build tree only; the test deps include a git dependency that
+# npm 12 refuses by default, and the image never runs tests.
 COPY ./react-frontend/package*.json /app/
-RUN npm install --no-audit
+RUN npm install --no-audit --omit=dev
 RUN npx update-browserslist-db@latest
 # Copy sources and build
 COPY ./react-frontend /app

--- a/compose/Dockerfile
+++ b/compose/Dockerfile
@@ -4,6 +4,10 @@ FROM node:24-bullseye AS builder
 LABEL maintainer="Ethan Andrews <eandrews@whoi.edu>"
 
 ENV NPM_CONFIG_LOGLEVEL=error
+# The test deps include a git dependency that npm 12 refuses by default, and the
+# image never runs tests. Config, not a flag, so the npm install that
+# update-browserslist-db shells out to inherits it too.
+ENV NPM_CONFIG_OMIT=dev
 
 WORKDIR /app
 
@@ -19,10 +23,9 @@ ARG npm_config_cafile=/etc/ssl/certs/ca-certificates.crt
 # deliberately, and rebuild once when you do.
 RUN npm i npm@12.0.2 -g
 
-# Install the build tree only; the test deps include a git dependency that
-# npm 12 refuses by default, and the image never runs tests.
+# Install the build tree only (see NPM_CONFIG_OMIT above).
 COPY ./react-frontend/package*.json /app/
-RUN npm install --no-audit --omit=dev
+RUN npm install --no-audit
 RUN npx update-browserslist-db@latest
 # Copy sources and build
 COPY ./react-frontend /app

--- a/configEnv-production.js
+++ b/configEnv-production.js
@@ -23,14 +23,3 @@ window.PILOT_VIDEO = "pilot";
 window.PILOT_SMALL_VIDEO = "pilot_small";
 
 /*
-window.CAMERAS = [
-  { camera: "camera1", cam_name: "port_brow_4k", owner: "port" },
-  { camera: "camera2", cam_name: "port_patz", owner: "port" },
-  { camera: "camera3", cam_name: "stbd_brow_4k", owner: "stbd" },
-  { camera: "camera4", cam_name: "stbd_patz", owner: "stbd" },
-  { camera: "camera5", cam_name: "aft_cam", owner: "none" },
-  { camera: "camera6", cam_name: "down_cam", owner: "none" },
-  { camera: "camera7", cam_name: "brow_wide", owner: "none" },
-  { camera: "camera8", cam_name: "sci_cam", owner: "pilot" },
-  { camera: "camera9", cam_name: "pilot_cam", owner: "pilot" },
-];

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^5.18.0",
         "@mui/styles": "^5.18.0",
         "@reduxjs/toolkit": "^1.6.0",
+        "@vitejs/plugin-react": "^4.3.1",
         "clsx": "^1.1.1",
         "date-fns": "^2.30.0",
         "lodash": "^4.17.21",
@@ -24,7 +25,8 @@
         "react-redux": "^8.0.5",
         "reselect": "^4.1.8",
         "socket.io-client": "^4.1.3",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "vite": "^5.4.0"
       },
       "devDependencies": {
         "@mswjs/interceptors": "^0.39.6",
@@ -32,9 +34,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/react": "^18.3.5",
-        "@vitejs/plugin-react": "^4.3.1",
         "jsdom": "^24.1.0",
-        "vite": "^5.4.0",
         "vitest": "^2.1.3"
       }
     },
@@ -42,7 +42,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -91,7 +90,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
       "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -101,7 +99,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.3.tgz",
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -148,7 +145,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -187,7 +183,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -205,7 +200,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -233,7 +227,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -243,7 +236,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.3.tgz",
       "integrity": "sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -272,7 +264,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -288,7 +279,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -650,7 +640,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,7 +656,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -684,7 +672,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -701,7 +688,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,7 +704,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -735,7 +720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -752,7 +736,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,7 +752,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -786,7 +768,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -803,7 +784,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -820,7 +800,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,7 +816,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -854,7 +832,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,7 +848,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -888,7 +864,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -905,7 +880,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -922,7 +896,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,7 +912,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -956,7 +928,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -973,7 +944,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,7 +960,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,7 +976,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1024,7 +992,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1565,7 +1532,6 @@
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1575,7 +1541,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,7 +1554,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1603,7 +1567,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1617,7 +1580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1631,7 +1593,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1645,7 +1606,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1659,7 +1619,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1673,7 +1632,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1687,7 +1645,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1701,7 +1658,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1715,7 +1671,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1729,7 +1684,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1743,7 +1697,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1757,7 +1710,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,7 +1723,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1785,7 +1736,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1799,7 +1749,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1813,7 +1762,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1827,7 +1775,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1841,7 +1788,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1929,7 +1875,6 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -1943,7 +1888,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -1953,7 +1897,6 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -1964,7 +1907,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -1982,7 +1924,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -2046,7 +1987,6 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -2268,7 +2208,6 @@
       "version": "4.25.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.4.tgz",
       "integrity": "sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2334,7 +2273,6 @@
       "version": "1.0.30001737",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
       "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2495,7 +2433,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -2684,7 +2621,6 @@
       "version": "1.5.211",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.211.tgz",
       "integrity": "sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -2837,7 +2773,6 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2876,7 +2811,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2941,7 +2875,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2965,7 +2898,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3316,7 +3248,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3457,7 +3388,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -3599,7 +3529,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3624,7 +3553,6 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nwsapi": {
@@ -3743,7 +3671,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3935,7 +3862,6 @@
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4040,7 +3966,6 @@
       "version": "4.49.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.49.0.tgz",
       "integrity": "sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -4116,7 +4041,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4218,7 +4142,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4451,7 +4374,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4511,7 +4433,6 @@
       "version": "5.4.19",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -4828,7 +4749,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -20,7 +20,9 @@
     "react-redux": "^8.0.5",
     "reselect": "^4.1.8",
     "socket.io-client": "^4.1.3",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "vite": "^5.4.0"
   },
   "scripts": {
     "start": "vite",
@@ -35,9 +37,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^18.3.5",
-    "@vitejs/plugin-react": "^4.3.1",
     "jsdom": "^24.1.0",
-    "vite": "^5.4.0",
     "vitest": "^2.1.3"
   },
   "overrides": {

--- a/react-frontend/public/configEnv.js
+++ b/react-frontend/public/configEnv.js
@@ -22,13 +22,3 @@ window.STBD_OBSERVER_VIDEO = "stbd_mon";
 window.STBD_RECORDER_VIDEO = "stbd_rec";
 window.PILOT_VIDEO = "pilot_mon";
 
-window.CAMERAS = [
-  { camera: "camera1", cam_name: "port_brow_4k", owner: "port" },
-  { camera: "camera2", cam_name: "port_patz", owner: "port" },
-  { camera: "camera3", cam_name: "stbd_brow_4k", owner: "stbd" },
-  { camera: "camera4", cam_name: "stbd_patz", owner: "stbd" },
-  { camera: "camera5", cam_name: "aft_cam", owner: "none" },
-  { camera: "camera6", cam_name: "down_cam", owner: "none" },
-  { camera: "camera7", cam_name: "brow_wide", owner: "pilot" },
-  { camera: "camera8", cam_name: "sci_cam", owner: "port" },
-];

--- a/react-frontend/src/config.js
+++ b/react-frontend/src/config.js
@@ -15,9 +15,6 @@ export const CAM_HEARTBEAT = "CamHeartbeat";
 export const SENSOR_HEARTBEAT = "SensorHeartbeat";
 export const RECORDER_HEARTBEAT = "RecorderHeartbeat";
 
-// Camera definitions
-//export const CAMERAS = envSettings.CAMERAS;
-
 // Camera command constants
 export const COMMAND_PREFIX = "COV"; // Client Observer. Combines with ObserverSide P/S
 export const COMMAND_STRINGS = {

--- a/react-frontend/src/features/system-messages/SystemMessagesPanel.jsx
+++ b/react-frontend/src/features/system-messages/SystemMessagesPanel.jsx
@@ -11,7 +11,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import DeleteSweepIcon from "@mui/icons-material/DeleteSweep";
 import DoneAllIcon from "@mui/icons-material/DoneAll";
 import {
-  dismissReadSystemMessages,
+  dismissAllSystemMessages,
   dismissSystemMessage,
   markAllSystemMessagesRead,
   selectSystemMessages,
@@ -109,21 +109,21 @@ export default function SystemMessagesPanel({
         <Tooltip title="Mark all read">
           <IconButton
             aria-label="Mark all system notifications read"
-            size="small"
+            size="large"
             onClick={() => dispatch(markAllSystemMessagesRead())}
             sx={{ color: "grey.300" }}
           >
-            <DoneAllIcon fontSize="small" />
+            <DoneAllIcon />
           </IconButton>
         </Tooltip>
-        <Tooltip title="Clear read">
+        <Tooltip title="Clear all">
           <IconButton
-            aria-label="Clear read system notifications"
-            size="small"
-            onClick={() => dispatch(dismissReadSystemMessages())}
+            aria-label="Clear all system notifications"
+            size="large"
+            onClick={() => dispatch(dismissAllSystemMessages())}
             sx={{ color: "grey.300" }}
           >
-            <DeleteSweepIcon fontSize="small" />
+            <DeleteSweepIcon />
           </IconButton>
         </Tooltip>
       </Stack>

--- a/react-frontend/src/features/system-messages/systemMessagesSlice.js
+++ b/react-frontend/src/features/system-messages/systemMessagesSlice.js
@@ -92,8 +92,8 @@ export const systemMessagesSlice = createSlice({
     dismissSystemMessage: (state, action) => {
       state.items = state.items.filter((message) => message.id !== action.payload);
     },
-    dismissReadSystemMessages: (state) => {
-      state.items = state.items.filter((message) => !message.read);
+    dismissAllSystemMessages: (state) => {
+      state.items = [];
     },
     removeExpiredSystemMessages: {
       reducer: (state, action) => {
@@ -116,7 +116,7 @@ export const systemMessagesSlice = createSlice({
 
 export const {
   addSystemMessage,
-  dismissReadSystemMessages,
+  dismissAllSystemMessages,
   dismissSystemMessage,
   markAllSystemMessagesRead,
   removeExpiredSystemMessages,

--- a/react-frontend/src/features/system-messages/systemMessagesSlice.test.js
+++ b/react-frontend/src/features/system-messages/systemMessagesSlice.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import reducer, {
   addSystemMessage,
-  dismissReadSystemMessages,
+  dismissAllSystemMessages,
   markAllSystemMessagesRead,
   removeExpiredSystemMessages,
   selectSystemMessages,
@@ -51,7 +51,7 @@ test("adds unread messages and summarizes severity", () => {
   expect(selectWorstSystemMessageLevel(rootState(state))).toBe("CRITICAL");
 });
 
-test("marks messages read and clears read messages", () => {
+test("marks messages read and clears all messages regardless of read state", () => {
   let state = reducer(undefined, { type: "@@INIT" });
 
   state = reducer(
@@ -73,7 +73,21 @@ test("marks messages read and clears read messages", () => {
   // Worst level reflects only unread messages, so reading clears it.
   expect(selectWorstSystemMessageLevel(rootState(state))).toBeNull();
 
-  state = reducer(state, dismissReadSystemMessages());
+  state = reducer(
+    state,
+    addSystemMessage(
+      {
+        correlation_id: "warn-1",
+        timestamp: "2026-06-15T12:01:00Z",
+        message: "Recorder unresponsive",
+        level: "WARN",
+      },
+      2000
+    )
+  );
+
+  // Clears everything, including the still-unread message.
+  state = reducer(state, dismissAllSystemMessages());
 
   expect(selectSystemMessages(rootState(state))).toHaveLength(0);
 });

--- a/react-frontend/src/hooks/useSocket.js
+++ b/react-frontend/src/hooks/useSocket.js
@@ -35,6 +35,8 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     return () => {
       const e = entryRef.current;
       if (!e) return;
+      // Clear first, or a render after teardown hands out the dead socket.
+      entryRef.current = null;
       e.refCount -= 1;
       if (e.refCount <= 0) {
         pool.delete(e.key);
@@ -52,9 +54,9 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     };
   }, [namespace, apiVersion]);
 
-  return entryRef.current
-    ? entryRef.current.socket
-    : getOrCreate(namespace, apiVersion).socket;
+  const live = entryRef.current;
+  if (live && pool.get(live.key) === live) return live.socket;
+  return getOrCreate(namespace, apiVersion).socket;
 }
 
 export function useSocketListener(

--- a/react-frontend/src/utils/webrtcplayer.js
+++ b/react-frontend/src/utils/webrtcplayer.js
@@ -18,6 +18,12 @@ const RECONNECT_MAX_MS = 10000;
 export const STATS_POLL_MS = 2000;
 export const STALL_LIMIT = 3; // consecutive idle polls (~6s) before reconnecting
 
+// A hidden tab stops decoding, so the counters freeze on a healthy stream;
+// iOS does this on lock/background.
+export function documentHidden() {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
 export default class WebRtcPlayer {
   static server = "http://127.0.0.1:8083";
   static protocol = "whep";
@@ -137,6 +143,12 @@ export default class WebRtcPlayer {
     if (this.closed || !this.webrtc) return;
     // Only meaningful once the transport claims to be up.
     if (this.webrtc.connectionState !== "connected") return;
+    // Baseline is dropped so the first poll after a resume starts fresh.
+    if (documentHidden()) {
+      this.lastSample = null;
+      this.stalledChecks = 0;
+      return;
+    }
     if (typeof this.webrtc.getStats !== "function") return;
 
     let frames = null;

--- a/react-frontend/src/utils/webrtcplayer.test.js
+++ b/react-frontend/src/utils/webrtcplayer.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import WebRtcPlayer, { STALL_LIMIT } from "./webrtcplayer";
+
+// Drives checkMediaProgress directly; a real RTCPeerConnection would only
+// test the browser.
+function playerWithFrozenStats() {
+  const player = Object.create(WebRtcPlayer.prototype);
+  player.closed = false;
+  player.lastSample = null;
+  player.stalledChecks = 0;
+  player.stream = "port_mon";
+  player.webrtc = {
+    connectionState: "connected",
+    getStats: async () => [
+      { type: "inbound-rtp", kind: "video", framesDecoded: 10, bytesReceived: 99 },
+    ],
+  };
+  player.scheduleReconnect = vi.fn();
+  player.stopStatsMonitor = vi.fn();
+  return player;
+}
+
+function setVisibility(state) {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+}
+
+describe("media-progress watchdog", () => {
+  beforeEach(() => setVisibility("visible"));
+  afterEach(() => setVisibility("visible"));
+
+  it("reconnects when frames stop advancing while visible", async () => {
+    const player = playerWithFrozenStats();
+
+    for (let i = 0; i <= STALL_LIMIT; i += 1) {
+      await player.checkMediaProgress();
+    }
+
+    expect(player.scheduleReconnect).toHaveBeenCalled();
+  });
+
+  it("does not reconnect while the tab is hidden", async () => {
+    // iOS stops decoding on lock/background; the counters freeze regardless.
+    const player = playerWithFrozenStats();
+    setVisibility("hidden");
+
+    for (let i = 0; i < STALL_LIMIT * 4; i += 1) {
+      await player.checkMediaProgress();
+    }
+
+    expect(player.scheduleReconnect).not.toHaveBeenCalled();
+    expect(player.stalledChecks).toBe(0);
+  });
+
+  it("needs a fresh baseline after a resume before it can stall", async () => {
+    const player = playerWithFrozenStats();
+    await player.checkMediaProgress();
+
+    setVisibility("hidden");
+    await player.checkMediaProgress();
+    expect(player.lastSample).toBeNull();
+
+    setVisibility("visible");
+    await player.checkMediaProgress();
+    expect(player.stalledChecks).toBe(0);
+    expect(player.scheduleReconnect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

- **Trash icon now clears all notifications.** It previously dispatched `dismissReadSystemMessages`, which kept any *unread* items, so unread alerts survived the click. Renamed to `dismissAllSystemMessages` (empties the list) and relabeled the button "Clear all". The per-message "X" still dismisses individual notifications.
- **Bigger, easier-to-click icons.** The header mark-all-read (✓✓) and clear (🗑) buttons went from `size="small"`/`fontSize="small"` to `size="large"` with default-size icons, roughly doubling the touch target.

## Test

Updated the slice test to confirm the trash action clears a still-**unread** message. All 11 `system-messages` tests pass.