### PR TITLE
Stop the iPads reconnecting video on every wake

### DIFF
--- a/configEnv-production.js
+++ b/configEnv-production.js
@@ -23,14 +23,3 @@ window.PILOT_VIDEO = "pilot";
 window.PILOT_SMALL_VIDEO = "pilot_small";
 
 /*
-window.CAMERAS = [
-  { camera: "camera1", cam_name: "port_brow_4k", owner: "port" },
-  { camera: "camera2", cam_name: "port_patz", owner: "port" },
-  { camera: "camera3", cam_name: "stbd_brow_4k", owner: "stbd" },
-  { camera: "camera4", cam_name: "stbd_patz", owner: "stbd" },
-  { camera: "camera5", cam_name: "aft_cam", owner: "none" },
-  { camera: "camera6", cam_name: "down_cam", owner: "none" },
-  { camera: "camera7", cam_name: "brow_wide", owner: "none" },
-  { camera: "camera8", cam_name: "sci_cam", owner: "pilot" },
-  { camera: "camera9", cam_name: "pilot_cam", owner: "pilot" },
-];

--- a/react-frontend/public/configEnv.js
+++ b/react-frontend/public/configEnv.js
@@ -22,13 +22,3 @@ window.STBD_OBSERVER_VIDEO = "stbd_mon";
 window.STBD_RECORDER_VIDEO = "stbd_rec";
 window.PILOT_VIDEO = "pilot_mon";
 
-window.CAMERAS = [
-  { camera: "camera1", cam_name: "port_brow_4k", owner: "port" },
-  { camera: "camera2", cam_name: "port_patz", owner: "port" },
-  { camera: "camera3", cam_name: "stbd_brow_4k", owner: "stbd" },
-  { camera: "camera4", cam_name: "stbd_patz", owner: "stbd" },
-  { camera: "camera5", cam_name: "aft_cam", owner: "none" },
-  { camera: "camera6", cam_name: "down_cam", owner: "none" },
-  { camera: "camera7", cam_name: "brow_wide", owner: "pilot" },
-  { camera: "camera8", cam_name: "sci_cam", owner: "port" },
-];

--- a/react-frontend/src/config.js
+++ b/react-frontend/src/config.js
@@ -15,9 +15,6 @@ export const CAM_HEARTBEAT = "CamHeartbeat";
 export const SENSOR_HEARTBEAT = "SensorHeartbeat";
 export const RECORDER_HEARTBEAT = "RecorderHeartbeat";
 
-// Camera definitions
-//export const CAMERAS = envSettings.CAMERAS;
-
 // Camera command constants
 export const COMMAND_PREFIX = "COV"; // Client Observer. Combines with ObserverSide P/S
 export const COMMAND_STRINGS = {

--- a/react-frontend/src/hooks/useSocket.js
+++ b/react-frontend/src/hooks/useSocket.js
@@ -35,6 +35,10 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     return () => {
       const e = entryRef.current;
       if (!e) return;
+      // Clear first: otherwise a render after teardown hands out the socket we
+      // are about to disconnect, and that consumer listens to a dead one for
+      // the rest of the session.
+      entryRef.current = null;
       e.refCount -= 1;
       if (e.refCount <= 0) {
         pool.delete(e.key);
@@ -52,9 +56,9 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     };
   }, [namespace, apiVersion]);
 
-  return entryRef.current
-    ? entryRef.current.socket
-    : getOrCreate(namespace, apiVersion).socket;
+  const live = entryRef.current;
+  if (live && pool.get(live.key) === live) return live.socket;
+  return getOrCreate(namespace, apiVersion).socket;
 }
 
 export function useSocketListener(

--- a/react-frontend/src/hooks/useSocket.js
+++ b/react-frontend/src/hooks/useSocket.js
@@ -35,9 +35,7 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     return () => {
       const e = entryRef.current;
       if (!e) return;
-      // Clear first: otherwise a render after teardown hands out the socket we
-      // are about to disconnect, and that consumer listens to a dead one for
-      // the rest of the session.
+      // Clear first, or a render after teardown hands out the dead socket.
       entryRef.current = null;
       e.refCount -= 1;
       if (e.refCount <= 0) {

--- a/react-frontend/src/utils/webrtcplayer.js
+++ b/react-frontend/src/utils/webrtcplayer.js
@@ -18,9 +18,8 @@ const RECONNECT_MAX_MS = 10000;
 export const STATS_POLL_MS = 2000;
 export const STALL_LIMIT = 3; // consecutive idle polls (~6s) before reconnecting
 
-// A hidden tab stops decoding, so the counters freeze and the watchdog would
-// tear down a healthy connection. iOS does this on lock/background, which is
-// why the iPads reconnect all dive and the always-on pilot PC does not.
+// A hidden tab stops decoding, so the counters freeze on a healthy stream;
+// iOS does this on lock/background.
 export function documentHidden() {
   return typeof document !== "undefined" && document.visibilityState === "hidden";
 }
@@ -144,8 +143,7 @@ export default class WebRtcPlayer {
     if (this.closed || !this.webrtc) return;
     // Only meaningful once the transport claims to be up.
     if (this.webrtc.connectionState !== "connected") return;
-    // Drop the baseline while hidden so the first poll after a resume compares
-    // against fresh counters rather than pre-suspend ones.
+    // Baseline is dropped so the first poll after a resume starts fresh.
     if (documentHidden()) {
       this.lastSample = null;
       this.stalledChecks = 0;

--- a/react-frontend/src/utils/webrtcplayer.js
+++ b/react-frontend/src/utils/webrtcplayer.js
@@ -18,6 +18,13 @@ const RECONNECT_MAX_MS = 10000;
 export const STATS_POLL_MS = 2000;
 export const STALL_LIMIT = 3; // consecutive idle polls (~6s) before reconnecting
 
+// A hidden tab stops decoding, so the counters freeze and the watchdog would
+// tear down a healthy connection. iOS does this on lock/background, which is
+// why the iPads reconnect all dive and the always-on pilot PC does not.
+export function documentHidden() {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
+}
+
 export default class WebRtcPlayer {
   static server = "http://127.0.0.1:8083";
   static protocol = "whep";
@@ -137,6 +144,13 @@ export default class WebRtcPlayer {
     if (this.closed || !this.webrtc) return;
     // Only meaningful once the transport claims to be up.
     if (this.webrtc.connectionState !== "connected") return;
+    // Drop the baseline while hidden so the first poll after a resume compares
+    // against fresh counters rather than pre-suspend ones.
+    if (documentHidden()) {
+      this.lastSample = null;
+      this.stalledChecks = 0;
+      return;
+    }
     if (typeof this.webrtc.getStats !== "function") return;
 
     let frames = null;

--- a/react-frontend/src/utils/webrtcplayer.test.js
+++ b/react-frontend/src/utils/webrtcplayer.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import WebRtcPlayer, { STALL_LIMIT } from "./webrtcplayer";
 
-// Drives checkMediaProgress directly: the stall decision is the whole point,
-// and standing up a real RTCPeerConnection would test the browser instead.
+// Drives checkMediaProgress directly; a real RTCPeerConnection would only
+// test the browser.
 function playerWithFrozenStats() {
   const player = Object.create(WebRtcPlayer.prototype);
   player.closed = false;
@@ -42,8 +42,7 @@ describe("media-progress watchdog", () => {
   });
 
   it("does not reconnect while the tab is hidden", async () => {
-    // iOS stops decoding on lock/background, so the counters freeze on a
-    // perfectly healthy connection.
+    // iOS stops decoding on lock/background; the counters freeze regardless.
     const player = playerWithFrozenStats();
     setVisibility("hidden");
 

--- a/react-frontend/src/utils/webrtcplayer.test.js
+++ b/react-frontend/src/utils/webrtcplayer.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import WebRtcPlayer, { STALL_LIMIT } from "./webrtcplayer";
+
+// Drives checkMediaProgress directly: the stall decision is the whole point,
+// and standing up a real RTCPeerConnection would test the browser instead.
+function playerWithFrozenStats() {
+  const player = Object.create(WebRtcPlayer.prototype);
+  player.closed = false;
+  player.lastSample = null;
+  player.stalledChecks = 0;
+  player.stream = "port_mon";
+  player.webrtc = {
+    connectionState: "connected",
+    getStats: async () => [
+      { type: "inbound-rtp", kind: "video", framesDecoded: 10, bytesReceived: 99 },
+    ],
+  };
+  player.scheduleReconnect = vi.fn();
+  player.stopStatsMonitor = vi.fn();
+  return player;
+}
+
+function setVisibility(state) {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+}
+
+describe("media-progress watchdog", () => {
+  beforeEach(() => setVisibility("visible"));
+  afterEach(() => setVisibility("visible"));
+
+  it("reconnects when frames stop advancing while visible", async () => {
+    const player = playerWithFrozenStats();
+
+    for (let i = 0; i <= STALL_LIMIT; i += 1) {
+      await player.checkMediaProgress();
+    }
+
+    expect(player.scheduleReconnect).toHaveBeenCalled();
+  });
+
+  it("does not reconnect while the tab is hidden", async () => {
+    // iOS stops decoding on lock/background, so the counters freeze on a
+    // perfectly healthy connection.
+    const player = playerWithFrozenStats();
+    setVisibility("hidden");
+
+    for (let i = 0; i < STALL_LIMIT * 4; i += 1) {
+      await player.checkMediaProgress();
+    }
+
+    expect(player.scheduleReconnect).not.toHaveBeenCalled();
+    expect(player.stalledChecks).toBe(0);
+  });
+
+  it("needs a fresh baseline after a resume before it can stall", async () => {
+    const player = playerWithFrozenStats();
+    await player.checkMediaProgress();
+
+    setVisibility("hidden");
+    await player.checkMediaProgress();
+    expect(player.lastSample).toBeNull();
+
+    setVisibility("visible");
+    await player.checkMediaProgress();
+    expect(player.stalledChecks).toBe(0);
+    expect(player.scheduleReconnect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
From the AL5369/AL5370 review.

**The "Reconnecting…" the crew reported is the video overlay, not the control
socket.** The port UI sent 9,904 commands that dive — more than starboard — so
control was working the whole time. `VideoStatusOverlay` maps
`PLAYER_STATUS.RECONNECTING` to that text.

**webrtc:** the media-progress watchdog reconnects when neither decoded frames
nor received bytes advance for ~6s. A hidden tab stops decoding, so both
counters freeze on a healthy connection. iOS does this on lock/background,
which is why the iPads churn and the always-on pilot PC does not. Skips the
check while hidden and drops the baseline so the first poll after a resume
compares fresh counters.

**useSocket:** the cleanup deleted the pool entry and disconnected the socket
but left `entryRef` pointing at it, and the render path only calls
`getOrCreate` when the ref is empty — so a component rendering after a teardown
got the dead socket and kept it. Latent rather than the cause here, but it
would produce exactly a stuck indicator.

**config:** drops the `CAMERAS` list. It's commented out in `config.js` and
absent from the deployed configEnv in ais-server-config, so nothing reads it,
but it still names a `down_cam` and `sci_cam` that don't match what the server
advertises. It cost me a wrong conclusion while investigating; the real list
comes from the AIS bootstrap.

83 tests pass, production build clean. Three new tests on the watchdog.

Not verified on hardware — the sub is remote with cameras off. The visibility
behaviour needs a real iPad to confirm.
