### PR TITLE
Omit dev deps via npm config so nested installs inherit it

### DIFF
--- a/compose/Dockerfile
+++ b/compose/Dockerfile
@@ -4,6 +4,10 @@ FROM node:24-bullseye AS builder
 LABEL maintainer="Ethan Andrews <eandrews@whoi.edu>"
 
 ENV NPM_CONFIG_LOGLEVEL=error
+# The test deps include a git dependency that npm 12 refuses by default, and the
+# image never runs tests. Config, not a flag, so the npm install that
+# update-browserslist-db shells out to inherits it too.
+ENV NPM_CONFIG_OMIT=dev
 
 WORKDIR /app
 
@@ -19,10 +23,9 @@ ARG npm_config_cafile=/etc/ssl/certs/ca-certificates.crt
 # deliberately, and rebuild once when you do.
 RUN npm i npm@12.0.2 -g
 
-# Install the build tree only; the test deps include a git dependency that
-# npm 12 refuses by default, and the image never runs tests.
+# Install the build tree only (see NPM_CONFIG_OMIT above).
 COPY ./react-frontend/package*.json /app/
-RUN npm install --no-audit --omit=dev
+RUN npm install --no-audit
 RUN npx update-browserslist-db@latest
 # Copy sources and build
 COPY ./react-frontend /app


### PR DESCRIPTION
Follow-up to #49, which got the install step past `EALLOWGIT` but not the step
after it:

```
STEP 9/11: RUN npx update-browserslist-db@latest
$ npm install caniuse-lite baseline-browser-mapping
npm error code EALLOWGIT
```

`update-browserslist-db` shells out to its own `npm install`, which re-reads
package.json with no flags and trips over the same git test dependency.
`--omit=dev` on our install line could never cover that.

Setting it as npm config instead covers every npm invocation in the builder
stage, nested ones included. The explicit flag on the install line is now
redundant and removed.

Replayed the builder steps locally against npm 12.0.2 with
`NPM_CONFIG_OMIT=dev` set:

- `npm install --no-audit` — 169 packages, no git fetch
- `npx update-browserslist-db@latest` — exit 0, caniuse-lite updated
- `npm run build` — clean

Dockerfile only; no package.json or lockfile change.
