### PR TITLE
Rebind observer sockets and clear camera state on a side switch

### DIFF
--- a/react-frontend/src/features/camera-controls/cameraControlsSlice.js
+++ b/react-frontend/src/features/camera-controls/cameraControlsSlice.js
@@ -47,6 +47,14 @@ export const cameraControlsSlice = createSlice({
   initialState: initialState,
   reducers: {
     setObserverSide: (state, action) => {
+      if (action.payload !== state.observerSide) {
+        // Heartbeat, active camera and settings belong to the station we are
+        // leaving; keep them and the new side renders the old one's cameras.
+        state.initialCamHeartbeat = null;
+        state.activeCamera = null;
+        state.camHeartbeatData = null;
+        state.currentCamData = null;
+      }
       state.observerSide = action.payload;
       if (action.payload === "P") {
         state.observerVideoSrc = VIDEO_STREAM_CONFIG.portObserverVideo;

--- a/react-frontend/src/features/camera-controls/cameraControlsSlice.test.js
+++ b/react-frontend/src/features/camera-controls/cameraControlsSlice.test.js
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import reducer, { setObserverSide } from "./cameraControlsSlice";
+
+const stationState = {
+  observerSide: "P",
+  initialCamHeartbeat: { camera: "port_cam" },
+  activeCamera: { camera: "port_cam" },
+  camHeartbeatData: { camera: "port_cam" },
+  currentCamData: { current_settings: {} },
+};
+
+test("switching sides drops the previous station's camera state", () => {
+  const next = reducer(stationState, setObserverSide("S"));
+  expect(next.observerSide).toBe("S");
+  expect(next.initialCamHeartbeat).toBeNull();
+  expect(next.activeCamera).toBeNull();
+  expect(next.camHeartbeatData).toBeNull();
+  expect(next.currentCamData).toBeNull();
+});
+
+test("re-selecting the same side keeps the camera state", () => {
+  const next = reducer(stationState, setObserverSide("P"));
+  expect(next.activeCamera).toEqual({ camera: "port_cam" });
+  expect(next.camHeartbeatData).toEqual({ camera: "port_cam" });
+});

--- a/react-frontend/src/hooks/useSocket.js
+++ b/react-frontend/src/hooks/useSocket.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import socketIOClient from "socket.io-client";
 import { WS_ENDPOINTS } from "../config";
 
@@ -25,20 +25,18 @@ function getOrCreate(namespace, apiVersion) {
 }
 
 export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
-  const entryRef = useRef(null);
+  // Resolved during render. A ref only updates in the effect, which does not
+  // re-render, so consumers kept the previous namespace's socket after a side
+  // switch and never rebound their listeners.
+  const entry = getOrCreate(namespace, apiVersion);
 
   useEffect(() => {
-    const entry = getOrCreate(namespace, apiVersion);
-    entry.refCount += 1;
-    entryRef.current = entry;
+    const e = getOrCreate(namespace, apiVersion);
+    e.refCount += 1;
 
     return () => {
-      const e = entryRef.current;
-      if (!e) return;
-      // Clear first, or a render after teardown hands out the dead socket.
-      entryRef.current = null;
       e.refCount -= 1;
-      if (e.refCount <= 0) {
+      if (e.refCount <= 0 && pool.get(e.key) === e) {
         pool.delete(e.key);
 
         // Good bye message to server is a historical part of the ICS protocol
@@ -54,9 +52,7 @@ export function useSocket(namespace = "/", { apiVersion = "1" } = {}) {
     };
   }, [namespace, apiVersion]);
 
-  const live = entryRef.current;
-  if (live && pool.get(live.key) === live) return live.socket;
-  return getOrCreate(namespace, apiVersion).socket;
+  return entry.socket;
 }
 
 export function useSocketListener(

--- a/react-frontend/src/hooks/useSocket.test.tsx
+++ b/react-frontend/src/hooks/useSocket.test.tsx
@@ -85,3 +85,38 @@ test("useSocketListener attaches and cleans up event handler", async () => {
   });
   expect(received).toBe(1);
 });
+
+function SideListener({
+  namespace,
+  onMessage,
+}: {
+  namespace: string;
+  onMessage: (m: any) => void;
+}) {
+  useSocketListener(namespace, "cam:heartbeat", onMessage);
+  return null;
+}
+
+test("useSocketListener rebinds when the namespace changes", async () => {
+  const h = createSocketIoHarness();
+  const seen: string[] = [];
+  const onMessage = (m: any) => seen.push(m.side);
+
+  const { rerender } = render(
+    <SideListener namespace="/port" onMessage={onMessage} />
+  );
+  await h.connected;
+
+  rerender(<SideListener namespace="/stbd" onMessage={onMessage} />);
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  await act(async () => {
+    h.emit({ event: "cam:heartbeat", namespace: "/port" }, { side: "port" });
+    h.emit({ event: "cam:heartbeat", namespace: "/stbd" }, { side: "stbd" });
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  expect(seen).toEqual(["stbd"]);
+});

--- a/react-frontend/tests/socket.io-harness.ts
+++ b/react-frontend/tests/socket.io-harness.ts
@@ -16,7 +16,7 @@ type ExpectEmitResult = {
 
 export type SocketIoHarness = {
   connected: Promise<void>;
-  emit(event: string, ...args: any[]): void;
+  emit(envelope: string | { event: string; namespace?: string }, ...args: any[]): void;
 
   // Allow attaching labeled expectations: h.someLabel = expectEmit("evt")
   [label: string]: any;
@@ -59,9 +59,9 @@ export function createSocketIoHarness(
   };
 
   const harness: SocketIoHarness = {
-    emit(event: string, ...args: any[]) {
+    emit(envelope: string | { event: string; namespace?: string }, ...args: any[]) {
       if (!io) throw new Error("Cannot emit - no connection yet");
-      io.client.emit(event, ...args); // as in server -> client
+      io.client.emit(envelope as any, ...args); // as in server -> client
     },
 
     // connected is a promise that gets resolved when the connection is


### PR DESCRIPTION
Switching an observer from port to starboard kept showing the port station.

Two causes:

- `useSocket` returned the socket stored in a ref, which is only written in the effect. Effects don't re-render, so on the render where the namespace changes the hook hands back the previous socket, `useSocketListener`'s `[socket, event]` deps don't change, and the listener is never rebound. The same effect then disconnects that socket and drops it from the pool, so the station goes quiet rather than merely stale. Resolved during render now; the pool is already keyed, so this is a lookup, not a new connection.

- `setObserverSide` swapped the video sources but left `initialCamHeartbeat`, `activeCamera`, `camHeartbeatData` and `currentCamData` alone. `ObserverUI` only re-seeds the camera while `activeCamera === null`, which never came back, so the panel stayed on the port camera. Cleared when the side actually changes.

`allCameras` is deliberately untouched — the server sends the full topology on both namespaces.

Tests: a rebind test in `useSocket.test.tsx` (fails without the hook change) and two reducer tests. Full suite passes, 86 tests.